### PR TITLE
fix: ' in curl command

### DIFF
--- a/docs/v1.0/en/quickstart/ava-getting-started.md
+++ b/docs/v1.0/en/quickstart/ava-getting-started.md
@@ -105,7 +105,7 @@ curl -X POST --data '{
         "address":"X-6cesTteH62Y5mLoDBUASaBvCXuL2AthL",
         "assetID":"AVA"
     }
-}'' -H 'content-type:application/json;' 127.0.0.1:9650/ext/X
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/X
 ```
 
 If the response is this:


### PR DESCRIPTION
The quickstart documentation has one typo in the first curl command : 
````
curl -X POST --data '{
    "jsonrpc":"2.0",
    "id"     :2,
    "method" :"avm.getBalance",
    "params" :{
        "address":"X-6cesTteH62Y5mLoDBUASaBvCXuL2AthL",
        "assetID":"AVA"
    }
}'' -H 'content-type:application/json;' 127.0.0.1:9650/ext/X
````

One `'` too many before the `-H 'content.....'