### PR TITLE
unnecessary comma on doc

### DIFF
--- a/docs/v1.0/en/api/avm.md
+++ b/docs/v1.0/en/api/avm.md
@@ -627,7 +627,7 @@ curl -X POST --data '{
         "to":"Bg6e45gxCUTLXcfUuoy3go2U6V3bRZ5jH",
         "amount": 500,
     	"username":"myUsername",
-    	"password":"myPassword",
+    	"password":"myPassword"
     }
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
 ```


### PR DESCRIPTION
This comma prevent curl call for - avm.exportAVA - method