### PR TITLE
Add missing `denomination` parameter for Slopes

### DIFF
--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_admin_api_.adminapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_admin_api_.adminapi.md
@@ -52,7 +52,7 @@ Class for interacting with a node's AdminAPI.
 
 *Overrides [JRPCAPI](_utils_types_.jrpcapi.md).[constructor](_utils_types_.jrpcapi.md#constructor)*
 
-*Defined in [apis/admin/api.ts:159](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L159)*
+*Defined in [apis/admin/api.ts:159](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L159)*
 
 This class should not be instantiated directly. Instead use the [Slopes.addAPI](_index_.slopes.md#addapi) method.
 
@@ -73,7 +73,7 @@ Name | Type | Default | Description |
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[jrpcVersion](_utils_types_.jrpcapi.md#protected-jrpcversion)*
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[rpcid](_utils_types_.jrpcapi.md#protected-rpcid)*
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **alias**(`endpoint`: string, `alias`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:48](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L48)*
+*Defined in [apis/admin/api.ts:48](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L48)*
 
 Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias.
 
@@ -144,7 +144,7 @@ ___
 
 ▸ **aliasChain**(`chain`: string, `alias`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:66](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L66)*
+*Defined in [apis/admin/api.ts:66](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L66)*
 
 Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used.
 
@@ -167,7 +167,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -187,7 +187,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -199,7 +199,7 @@ ___
 
 ▸ **getBlockchainID**(`alias`: string): *Promise‹string›*
 
-*Defined in [apis/admin/api.ts:83](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L83)*
+*Defined in [apis/admin/api.ts:83](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L83)*
 
 Fetches the blockchainID from the node for a given alias.
 
@@ -221,7 +221,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -233,7 +233,7 @@ ___
 
 ▸ **getNetworkID**(): *Promise‹number›*
 
-*Defined in [apis/admin/api.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L33)*
+*Defined in [apis/admin/api.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L33)*
 
 Fetches the networkID from the node.
 
@@ -247,7 +247,7 @@ ___
 
 ▸ **getNodeID**(): *Promise‹string›*
 
-*Defined in [apis/admin/api.ts:21](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L21)*
+*Defined in [apis/admin/api.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L21)*
 
 Fetches the nodeID from the node.
 
@@ -263,7 +263,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -275,7 +275,7 @@ ___
 
 ▸ **lockProfile**(`filename`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:99](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L99)*
+*Defined in [apis/admin/api.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L99)*
 
 Dump the mutex statistics of the node to the specified file.
 
@@ -295,7 +295,7 @@ ___
 
 ▸ **memoryProfile**(`filename`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:115](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L115)*
+*Defined in [apis/admin/api.ts:115](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L115)*
 
 Dump the current memory footprint of the node to the specified file.
 
@@ -315,7 +315,7 @@ ___
 
 ▸ **peers**(): *Promise‹Array‹string››*
 
-*Defined in [apis/admin/api.ts:129](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L129)*
+*Defined in [apis/admin/api.ts:129](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L129)*
 
 Returns the peers connected to the node.
 
@@ -331,7 +331,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 
@@ -349,7 +349,7 @@ ___
 
 ▸ **startCPUProfiler**(`filename`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:141](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L141)*
+*Defined in [apis/admin/api.ts:141](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L141)*
 
 Start profiling the cpu utilization of the node. Will dump the profile information into the specified file on stop.
 
@@ -369,7 +369,7 @@ ___
 
 ▸ **stopCPUProfiler**(): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:155](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/admin/api.ts#L155)*
+*Defined in [apis/admin/api.ts:155](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L155)*
 
 Stop the CPU profile that was previously started.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_admin_api_.adminapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_admin_api_.adminapi.md
@@ -52,7 +52,7 @@ Class for interacting with a node's AdminAPI.
 
 *Overrides [JRPCAPI](_utils_types_.jrpcapi.md).[constructor](_utils_types_.jrpcapi.md#constructor)*
 
-*Defined in [apis/admin/api.ts:159](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L159)*
+*Defined in [apis/admin/api.ts:159](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L159)*
 
 This class should not be instantiated directly. Instead use the [Slopes.addAPI](_index_.slopes.md#addapi) method.
 
@@ -73,7 +73,7 @@ Name | Type | Default | Description |
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L33)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L32)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L34)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[jrpcVersion](_utils_types_.jrpcapi.md#protected-jrpcversion)*
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L80)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[rpcid](_utils_types_.jrpcapi.md#protected-rpcid)*
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **alias**(`endpoint`: string, `alias`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:48](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L48)*
+*Defined in [apis/admin/api.ts:48](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L48)*
 
 Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias.
 
@@ -144,7 +144,7 @@ ___
 
 ▸ **aliasChain**(`chain`: string, `alias`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:66](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L66)*
+*Defined in [apis/admin/api.ts:66](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L66)*
 
 Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used.
 
@@ -167,7 +167,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -187,7 +187,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -199,7 +199,7 @@ ___
 
 ▸ **getBlockchainID**(`alias`: string): *Promise‹string›*
 
-*Defined in [apis/admin/api.ts:83](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L83)*
+*Defined in [apis/admin/api.ts:83](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L83)*
 
 Fetches the blockchainID from the node for a given alias.
 
@@ -221,7 +221,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -233,7 +233,7 @@ ___
 
 ▸ **getNetworkID**(): *Promise‹number›*
 
-*Defined in [apis/admin/api.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L33)*
+*Defined in [apis/admin/api.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L33)*
 
 Fetches the networkID from the node.
 
@@ -247,7 +247,7 @@ ___
 
 ▸ **getNodeID**(): *Promise‹string›*
 
-*Defined in [apis/admin/api.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L21)*
+*Defined in [apis/admin/api.ts:21](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L21)*
 
 Fetches the nodeID from the node.
 
@@ -263,7 +263,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -275,7 +275,7 @@ ___
 
 ▸ **lockProfile**(`filename`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L99)*
+*Defined in [apis/admin/api.ts:99](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L99)*
 
 Dump the mutex statistics of the node to the specified file.
 
@@ -295,7 +295,7 @@ ___
 
 ▸ **memoryProfile**(`filename`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:115](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L115)*
+*Defined in [apis/admin/api.ts:115](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L115)*
 
 Dump the current memory footprint of the node to the specified file.
 
@@ -315,7 +315,7 @@ ___
 
 ▸ **peers**(): *Promise‹Array‹string››*
 
-*Defined in [apis/admin/api.ts:129](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L129)*
+*Defined in [apis/admin/api.ts:129](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L129)*
 
 Returns the peers connected to the node.
 
@@ -331,7 +331,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 
@@ -349,7 +349,7 @@ ___
 
 ▸ **startCPUProfiler**(`filename`: string): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:141](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L141)*
+*Defined in [apis/admin/api.ts:141](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L141)*
 
 Start profiling the cpu utilization of the node. Will dump the profile information into the specified file on stop.
 
@@ -369,7 +369,7 @@ ___
 
 ▸ **stopCPUProfiler**(): *Promise‹boolean›*
 
-*Defined in [apis/admin/api.ts:155](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/admin/api.ts#L155)*
+*Defined in [apis/admin/api.ts:155](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/admin/api.ts#L155)*
 
 Stop the CPU profile that was previously started.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_api_.avmapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_api_.avmapi.md
@@ -73,7 +73,7 @@ Class for interacting with a node endpoint that is using the AVM.
 
 *Overrides [JRPCAPI](_utils_types_.jrpcapi.md).[constructor](_utils_types_.jrpcapi.md#constructor)*
 
-*Defined in [apis/avm/api.ts:822](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L822)*
+*Defined in [apis/avm/api.ts:822](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L822)*
 
 This class should not be instantiated directly. Instead use the [Slopes.addAPI](_index_.slopes.md#addapi) method.
 
@@ -93,7 +93,7 @@ Name | Type | Default | Description |
 
 • **AVAAssetID**: *Buffer* =  undefined
 
-*Defined in [apis/avm/api.ts:88](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L88)*
+*Defined in [apis/avm/api.ts:88](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L88)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L33)*
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 • **blockchainID**: *string* = ""
 
-*Defined in [apis/avm/api.ts:87](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L87)*
+*Defined in [apis/avm/api.ts:87](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L87)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L32)*
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L34)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[jrpcVersion](_utils_types_.jrpcapi.md#protected-jrpcversion)*
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L80)*
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[rpcid](_utils_types_.jrpcapi.md#protected-rpcid)*
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **addressFromBuffer**(`address`: Buffer): *string*
 
-*Defined in [apis/avm/api.ts:143](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L143)*
+*Defined in [apis/avm/api.ts:143](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L143)*
 
 **Parameters:**
 
@@ -175,7 +175,7 @@ ___
 
 ▸ **buildGenesis**(`genesisData`: object): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:792](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L792)*
+*Defined in [apis/avm/api.ts:792](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L792)*
 
 Given a JSON representation of this Virtual Machine’s genesis state, create the byte representation of that state.
 
@@ -197,7 +197,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -215,7 +215,7 @@ ___
 
 ▸ **createAddress**(`username`: string, `password`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:215](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L215)*
+*Defined in [apis/avm/api.ts:215](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L215)*
 
 Creates an address (and associated private keys) on a user on a blockchain.
 
@@ -236,7 +236,7 @@ ___
 
 ▸ **createFixedCapAsset**(`username`: string, `password`: string, `name`: string, `symbol`: string, `denomination`: number, `initialHolders`: Array‹object›): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:251](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L251)*
+*Defined in [apis/avm/api.ts:251](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L251)*
 
 Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and there no more is ever created.
 
@@ -261,7 +261,7 @@ ___
 
 ▸ **createMintTx**(`amount`: number | BN, `assetID`: Buffer | string, `to`: string, `minters`: Array‹string›): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:321](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L321)*
+*Defined in [apis/avm/api.ts:321](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L321)*
 
 Create an unsigned transaction to mint more of an asset.
 
@@ -284,7 +284,7 @@ ___
 
 ▸ **createVariableCapAsset**(`username`: string, `password`: string, `name`: string, `symbol`: string, `denomination`: number, `minterSets`: Array‹object›): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L297)*
+*Defined in [apis/avm/api.ts:297](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L297)*
 
 Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using createMintTx, signMintTx and sendMintTx.
 
@@ -309,7 +309,7 @@ ___
 
 ▸ **exportAVA**(`username`: string, `password`: string, `to`: string, `amount`: BN): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:427](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L427)*
+*Defined in [apis/avm/api.ts:427](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L427)*
 
 Send AVA from the X-Chain to an account on the P-Chain.
 
@@ -334,7 +334,7 @@ ___
 
 ▸ **exportKey**(`username`: string, `password`: string, `address`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:380](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L380)*
+*Defined in [apis/avm/api.ts:380](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L380)*
 
 Exports the private key for an address.
 
@@ -356,7 +356,7 @@ ___
 
 ▸ **getAVAAssetID**(): *Promise‹Buffer›*
 
-*Defined in [apis/avm/api.ts:153](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L153)*
+*Defined in [apis/avm/api.ts:153](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L153)*
 
 Fetches the AVA AssetID and returns it in a Promise.
 
@@ -370,7 +370,7 @@ ___
 
 ▸ **getAllBalances**(`address`: string): *Promise‹Array‹object››*
 
-*Defined in [apis/avm/api.ts:486](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L486)*
+*Defined in [apis/avm/api.ts:486](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L486)*
 
 Retrieves all assets for an address on a server and their associated balances.
 
@@ -390,7 +390,7 @@ ___
 
 ▸ **getAssetDescription**(`assetID`: Buffer | string): *Promise‹object›*
 
-*Defined in [apis/avm/api.ts:506](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L506)*
+*Defined in [apis/avm/api.ts:506](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L506)*
 
 Retrieves an assets name and symbol.
 
@@ -410,7 +410,7 @@ ___
 
 ▸ **getBalance**(`address`: string, `assetID`: string): *Promise‹BN›*
 
-*Defined in [apis/avm/api.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L192)*
+*Defined in [apis/avm/api.ts:192](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L192)*
 
 Gets the balance of a particular asset on a blockchain.
 
@@ -433,7 +433,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -445,7 +445,7 @@ ___
 
 ▸ **getBlockchainAlias**(): *string*
 
-*Defined in [apis/avm/api.ts:95](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L95)*
+*Defined in [apis/avm/api.ts:95](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L95)*
 
 Gets the alias for the blockchainID if it exists, otherwise returns `undefined`.
 
@@ -459,7 +459,7 @@ ___
 
 ▸ **getBlockchainID**(): *string*
 
-*Defined in [apis/avm/api.ts:109](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L109)*
+*Defined in [apis/avm/api.ts:109](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L109)*
 
 Gets the blockchainID and returns it.
 
@@ -475,7 +475,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -489,7 +489,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -501,7 +501,7 @@ ___
 
 ▸ **getTxStatus**(`txid`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:533](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L533)*
+*Defined in [apis/avm/api.ts:533](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L533)*
 
 Returns the status of a provided transaction ID by calling the node's `getTxStatus` method.
 
@@ -521,7 +521,7 @@ ___
 
 ▸ **getUTXOs**(`addresses`: Array‹string› | Array‹Buffer›, `persistOpts`: [PersistanceOptions](_apis_avm_api_.persistanceoptions.md)): *Promise‹[UTXOSet](_apis_avm_utxos_.utxoset.md)›*
 
-*Defined in [apis/avm/api.ts:552](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L552)*
+*Defined in [apis/avm/api.ts:552](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L552)*
 
 Retrieves the UTXOs related to the addresses provided from the node's `getUTXOs` method.
 
@@ -540,7 +540,7 @@ ___
 
 ▸ **importAVA**(`username`: string, `password`: string, `to`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:450](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L450)*
+*Defined in [apis/avm/api.ts:450](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L450)*
 
 Finalize a transfer of AVA from the P-Chain to the X-Chain.
 
@@ -564,7 +564,7 @@ ___
 
 ▸ **importKey**(`username`: string, `password`: string, `privateKey`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:404](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L404)*
+*Defined in [apis/avm/api.ts:404](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L404)*
 
 Imports a private key into the node's keystore under an user and for a blockchain.
 
@@ -586,7 +586,7 @@ ___
 
 ▸ **issueTx**(`tx`: string | Buffer | [Tx](_apis_avm_tx_.tx.md)): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:716](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L716)*
+*Defined in [apis/avm/api.ts:716](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L716)*
 
 Calls the node's issueTx method from the API and returns the resulting transaction ID as a string.
 
@@ -606,7 +606,7 @@ ___
 
 ▸ **keyChain**(): *[AVMKeyChain](_apis_avm_keychain_.avmkeychain.md)*
 
-*Defined in [apis/avm/api.ts:166](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L166)*
+*Defined in [apis/avm/api.ts:166](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L166)*
 
 Gets a reference to the keychain for this class.
 
@@ -620,7 +620,7 @@ ___
 
 ▸ **listAddresses**(`username`: string, `password`: string): *Promise‹Array‹string››*
 
-*Defined in [apis/avm/api.ts:469](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L469)*
+*Defined in [apis/avm/api.ts:469](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L469)*
 
 Lists all the addresses under a user.
 
@@ -641,7 +641,7 @@ ___
 
 ▸ **makeBaseTx**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `amount`: BN, `toAddresses`: Array‹string›, `fromAddresses`: Array‹string›, `changeAddresses`: Array‹string›, `assetID`: Buffer | string, `asOf`: BN, `locktime`: BN, `threshold`: number): *Promise‹[UnsignedTx](_apis_avm_tx_.unsignedtx.md)›*
 
-*Defined in [apis/avm/api.ts:598](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L598)*
+*Defined in [apis/avm/api.ts:598](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L598)*
 
 Helper function which creates an unsigned transaction. For more granular control, you may create your own
 [UnsignedTx](_apis_avm_tx_.unsignedtx.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s, and [[TransferOperation]]s).
@@ -670,7 +670,7 @@ ___
 
 ▸ **makeCreateAssetTx**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `fee`: BN, `creatorAddresses`: Array‹string› | Array‹Buffer›, `initialStates`: [InitialStates](_apis_avm_types_.initialstates.md), `name`: string, `symbol`: string, `denomination`: number): *Promise‹[UnsignedTx](_apis_avm_tx_.unsignedtx.md)›*
 
-*Defined in [apis/avm/api.ts:675](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L675)*
+*Defined in [apis/avm/api.ts:675](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L675)*
 
 Creates an unsigned transaction. For more granular control, you may create your own
 [UnsignedTx](_apis_avm_tx_.unsignedtx.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s, and [[TransferOperation]]s).
@@ -697,7 +697,7 @@ ___
 
 ▸ **makeNFTTransferTx**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `utxoid`: string | Array‹string›, `toAddresses`: Array‹string›, `fromAddresses`: Array‹string›, `feeAmount`: BN, `feeAddresses`: Array‹string›, `asOf`: BN, `locktime`: BN, `threshold`: number): *Promise‹[UnsignedTx](_apis_avm_tx_.unsignedtx.md)›*
 
-*Defined in [apis/avm/api.ts:637](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L637)*
+*Defined in [apis/avm/api.ts:637](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L637)*
 
 Helper function which creates an unsigned NFT Transfer. For more granular control, you may create your own
 [UnsignedTx](_apis_avm_tx_.unsignedtx.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s, and [[TransferOperation]]s).
@@ -726,7 +726,7 @@ ___
 
 ▸ **parseAddress**(`addr`: string): *Buffer*
 
-*Defined in [apis/avm/api.ts:137](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L137)*
+*Defined in [apis/avm/api.ts:137](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L137)*
 
 Takes an address string and returns its [Buffer](https://github.com/feross/buffer) representation if valid.
 
@@ -746,7 +746,7 @@ ___
 
 ▸ **refreshBlockchainID**(`blockchainID`: string): *boolean*
 
-*Defined in [apis/avm/api.ts:120](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L120)*
+*Defined in [apis/avm/api.ts:120](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L120)*
 
 Refresh blockchainID, and if a blockchainID is passed in, use that.
 
@@ -766,7 +766,7 @@ ___
 
 ▸ **send**(`username`: string, `password`: string, `assetID`: string | Buffer, `amount`: number | BN, `to`: string, `from`: Array‹string› | Array‹Buffer›): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:750](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L750)*
+*Defined in [apis/avm/api.ts:750](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L750)*
 
 Sends an amount of assetID to the specified address from a list of owned of addresses.
 
@@ -793,7 +793,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 
@@ -811,7 +811,7 @@ ___
 
 ▸ **signMintTx**(`username`: string, `password`: string, `tx`: string | Buffer, `minter`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:355](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L355)*
+*Defined in [apis/avm/api.ts:355](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L355)*
 
 Sign an unsigned or partially signed mint transaction.
 
@@ -834,7 +834,7 @@ ___
 
 ▸ **signTx**(`utx`: [UnsignedTx](_apis_avm_tx_.unsignedtx.md)): *[Tx](_apis_avm_tx_.tx.md)*
 
-*Defined in [apis/avm/api.ts:705](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L705)*
+*Defined in [apis/avm/api.ts:705](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L705)*
 
 Helper function which takes an unsigned transaction and signs it, returning the resulting [Tx](_apis_avm_tx_.tx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_api_.avmapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_api_.avmapi.md
@@ -73,7 +73,7 @@ Class for interacting with a node endpoint that is using the AVM.
 
 *Overrides [JRPCAPI](_utils_types_.jrpcapi.md).[constructor](_utils_types_.jrpcapi.md#constructor)*
 
-*Defined in [apis/avm/api.ts:818](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L818)*
+*Defined in [apis/avm/api.ts:822](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L822)*
 
 This class should not be instantiated directly. Instead use the [Slopes.addAPI](_index_.slopes.md#addapi) method.
 
@@ -93,7 +93,7 @@ Name | Type | Default | Description |
 
 • **AVAAssetID**: *Buffer* =  undefined
 
-*Defined in [apis/avm/api.ts:88](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L88)*
+*Defined in [apis/avm/api.ts:88](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L88)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 • **blockchainID**: *string* = ""
 
-*Defined in [apis/avm/api.ts:87](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L87)*
+*Defined in [apis/avm/api.ts:87](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L87)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[jrpcVersion](_utils_types_.jrpcapi.md#protected-jrpcversion)*
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[rpcid](_utils_types_.jrpcapi.md#protected-rpcid)*
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **addressFromBuffer**(`address`: Buffer): *string*
 
-*Defined in [apis/avm/api.ts:143](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L143)*
+*Defined in [apis/avm/api.ts:143](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L143)*
 
 **Parameters:**
 
@@ -175,7 +175,7 @@ ___
 
 ▸ **buildGenesis**(`genesisData`: object): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:788](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L788)*
+*Defined in [apis/avm/api.ts:792](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L792)*
 
 Given a JSON representation of this Virtual Machine’s genesis state, create the byte representation of that state.
 
@@ -197,7 +197,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -215,7 +215,7 @@ ___
 
 ▸ **createAddress**(`username`: string, `password`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:215](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L215)*
+*Defined in [apis/avm/api.ts:215](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L215)*
 
 Creates an address (and associated private keys) on a user on a blockchain.
 
@@ -234,9 +234,9 @@ ___
 
 ###  createFixedCapAsset
 
-▸ **createFixedCapAsset**(`username`: string, `password`: string, `name`: string, `symbol`: string, `initialHolders`: Array‹object›): *Promise‹string›*
+▸ **createFixedCapAsset**(`username`: string, `password`: string, `name`: string, `symbol`: string, `denomination`: number, `initialHolders`: Array‹object›): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:250](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L250)*
+*Defined in [apis/avm/api.ts:251](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L251)*
 
 Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and there no more is ever created.
 
@@ -248,6 +248,7 @@ Name | Type | Description |
 `password` | string | The password for the user paying the transaction fee (in $AVA) for asset creation |
 `name` | string | The human-readable name for the asset |
 `symbol` | string | Optional. The shorthand symbol for the asset. Between 0 and 4 characters |
+`denomination` | number | Optional. Determines how balances of this asset are displayed by user interfaces. Default is 0 |
 `initialHolders` | Array‹object› | An array of objects containing the field "address" and "amount" to establish the genesis values for the new asset  ```js Example initialHolders: [     {         "address": "X-7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh",         "amount": 10000     },     {         "address": "X-7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh",         "amount": 50000     } ] ```  |
 
 **Returns:** *Promise‹string›*
@@ -260,7 +261,7 @@ ___
 
 ▸ **createMintTx**(`amount`: number | BN, `assetID`: Buffer | string, `to`: string, `minters`: Array‹string›): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:317](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L317)*
+*Defined in [apis/avm/api.ts:321](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L321)*
 
 Create an unsigned transaction to mint more of an asset.
 
@@ -281,9 +282,9 @@ ___
 
 ###  createVariableCapAsset
 
-▸ **createVariableCapAsset**(`username`: string, `password`: string, `name`: string, `symbol`: string, `minterSets`: Array‹object›): *Promise‹string›*
+▸ **createVariableCapAsset**(`username`: string, `password`: string, `name`: string, `symbol`: string, `denomination`: number, `minterSets`: Array‹object›): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:294](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L294)*
+*Defined in [apis/avm/api.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L297)*
 
 Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using createMintTx, signMintTx and sendMintTx.
 
@@ -295,6 +296,7 @@ Name | Type | Description |
 `password` | string | The password for the user paying the transaction fee (in $AVA) for asset creation |
 `name` | string | The human-readable name for the asset |
 `symbol` | string | Optional. The shorthand symbol for the asset -- between 0 and 4 characters |
+`denomination` | number | Optional. Determines how balances of this asset are displayed by user interfaces. Default is 0 |
 `minterSets` | Array‹object› | is a list where each element specifies that threshold of the addresses in minters may together mint more of the asset by signing a minting transaction  ```js Example minterSets: [      {          "minters":[              "X-4peJsFvhdn7XjhNF4HWAQy6YaJts27s9q"          ],          "threshold": 1      },      {          "minters": [              "X-dcJ6z9duLfyQTgbjq2wBCowkvcPZHVDF",              "X-2fE6iibqfERz5wenXE6qyvinsxDvFhHZk",              "X-7ieAJbfrGQbpNZRAQEpZCC1Gs1z5gz4HU"          ],          "threshold": 2      } ] ```  |
 
 **Returns:** *Promise‹string›*
@@ -307,7 +309,7 @@ ___
 
 ▸ **exportAVA**(`username`: string, `password`: string, `to`: string, `amount`: BN): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:423](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L423)*
+*Defined in [apis/avm/api.ts:427](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L427)*
 
 Send AVA from the X-Chain to an account on the P-Chain.
 
@@ -332,7 +334,7 @@ ___
 
 ▸ **exportKey**(`username`: string, `password`: string, `address`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:376](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L376)*
+*Defined in [apis/avm/api.ts:380](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L380)*
 
 Exports the private key for an address.
 
@@ -354,7 +356,7 @@ ___
 
 ▸ **getAVAAssetID**(): *Promise‹Buffer›*
 
-*Defined in [apis/avm/api.ts:153](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L153)*
+*Defined in [apis/avm/api.ts:153](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L153)*
 
 Fetches the AVA AssetID and returns it in a Promise.
 
@@ -368,7 +370,7 @@ ___
 
 ▸ **getAllBalances**(`address`: string): *Promise‹Array‹object››*
 
-*Defined in [apis/avm/api.ts:482](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L482)*
+*Defined in [apis/avm/api.ts:486](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L486)*
 
 Retrieves all assets for an address on a server and their associated balances.
 
@@ -388,7 +390,7 @@ ___
 
 ▸ **getAssetDescription**(`assetID`: Buffer | string): *Promise‹object›*
 
-*Defined in [apis/avm/api.ts:502](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L502)*
+*Defined in [apis/avm/api.ts:506](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L506)*
 
 Retrieves an assets name and symbol.
 
@@ -408,7 +410,7 @@ ___
 
 ▸ **getBalance**(`address`: string, `assetID`: string): *Promise‹BN›*
 
-*Defined in [apis/avm/api.ts:192](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L192)*
+*Defined in [apis/avm/api.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L192)*
 
 Gets the balance of a particular asset on a blockchain.
 
@@ -431,7 +433,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -443,7 +445,7 @@ ___
 
 ▸ **getBlockchainAlias**(): *string*
 
-*Defined in [apis/avm/api.ts:95](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L95)*
+*Defined in [apis/avm/api.ts:95](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L95)*
 
 Gets the alias for the blockchainID if it exists, otherwise returns `undefined`.
 
@@ -457,7 +459,7 @@ ___
 
 ▸ **getBlockchainID**(): *string*
 
-*Defined in [apis/avm/api.ts:109](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L109)*
+*Defined in [apis/avm/api.ts:109](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L109)*
 
 Gets the blockchainID and returns it.
 
@@ -473,7 +475,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -487,7 +489,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -499,7 +501,7 @@ ___
 
 ▸ **getTxStatus**(`txid`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:529](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L529)*
+*Defined in [apis/avm/api.ts:533](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L533)*
 
 Returns the status of a provided transaction ID by calling the node's `getTxStatus` method.
 
@@ -519,7 +521,7 @@ ___
 
 ▸ **getUTXOs**(`addresses`: Array‹string› | Array‹Buffer›, `persistOpts`: [PersistanceOptions](_apis_avm_api_.persistanceoptions.md)): *Promise‹[UTXOSet](_apis_avm_utxos_.utxoset.md)›*
 
-*Defined in [apis/avm/api.ts:548](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L548)*
+*Defined in [apis/avm/api.ts:552](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L552)*
 
 Retrieves the UTXOs related to the addresses provided from the node's `getUTXOs` method.
 
@@ -538,7 +540,7 @@ ___
 
 ▸ **importAVA**(`username`: string, `password`: string, `to`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:446](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L446)*
+*Defined in [apis/avm/api.ts:450](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L450)*
 
 Finalize a transfer of AVA from the P-Chain to the X-Chain.
 
@@ -562,7 +564,7 @@ ___
 
 ▸ **importKey**(`username`: string, `password`: string, `privateKey`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:400](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L400)*
+*Defined in [apis/avm/api.ts:404](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L404)*
 
 Imports a private key into the node's keystore under an user and for a blockchain.
 
@@ -584,7 +586,7 @@ ___
 
 ▸ **issueTx**(`tx`: string | Buffer | [Tx](_apis_avm_tx_.tx.md)): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:712](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L712)*
+*Defined in [apis/avm/api.ts:716](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L716)*
 
 Calls the node's issueTx method from the API and returns the resulting transaction ID as a string.
 
@@ -604,7 +606,7 @@ ___
 
 ▸ **keyChain**(): *[AVMKeyChain](_apis_avm_keychain_.avmkeychain.md)*
 
-*Defined in [apis/avm/api.ts:166](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L166)*
+*Defined in [apis/avm/api.ts:166](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L166)*
 
 Gets a reference to the keychain for this class.
 
@@ -618,7 +620,7 @@ ___
 
 ▸ **listAddresses**(`username`: string, `password`: string): *Promise‹Array‹string››*
 
-*Defined in [apis/avm/api.ts:465](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L465)*
+*Defined in [apis/avm/api.ts:469](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L469)*
 
 Lists all the addresses under a user.
 
@@ -639,7 +641,7 @@ ___
 
 ▸ **makeBaseTx**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `amount`: BN, `toAddresses`: Array‹string›, `fromAddresses`: Array‹string›, `changeAddresses`: Array‹string›, `assetID`: Buffer | string, `asOf`: BN, `locktime`: BN, `threshold`: number): *Promise‹[UnsignedTx](_apis_avm_tx_.unsignedtx.md)›*
 
-*Defined in [apis/avm/api.ts:594](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L594)*
+*Defined in [apis/avm/api.ts:598](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L598)*
 
 Helper function which creates an unsigned transaction. For more granular control, you may create your own
 [UnsignedTx](_apis_avm_tx_.unsignedtx.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s, and [[TransferOperation]]s).
@@ -668,7 +670,7 @@ ___
 
 ▸ **makeCreateAssetTx**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `fee`: BN, `creatorAddresses`: Array‹string› | Array‹Buffer›, `initialStates`: [InitialStates](_apis_avm_types_.initialstates.md), `name`: string, `symbol`: string, `denomination`: number): *Promise‹[UnsignedTx](_apis_avm_tx_.unsignedtx.md)›*
 
-*Defined in [apis/avm/api.ts:671](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L671)*
+*Defined in [apis/avm/api.ts:675](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L675)*
 
 Creates an unsigned transaction. For more granular control, you may create your own
 [UnsignedTx](_apis_avm_tx_.unsignedtx.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s, and [[TransferOperation]]s).
@@ -695,7 +697,7 @@ ___
 
 ▸ **makeNFTTransferTx**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `utxoid`: string | Array‹string›, `toAddresses`: Array‹string›, `fromAddresses`: Array‹string›, `feeAmount`: BN, `feeAddresses`: Array‹string›, `asOf`: BN, `locktime`: BN, `threshold`: number): *Promise‹[UnsignedTx](_apis_avm_tx_.unsignedtx.md)›*
 
-*Defined in [apis/avm/api.ts:633](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L633)*
+*Defined in [apis/avm/api.ts:637](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L637)*
 
 Helper function which creates an unsigned NFT Transfer. For more granular control, you may create your own
 [UnsignedTx](_apis_avm_tx_.unsignedtx.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s, and [[TransferOperation]]s).
@@ -724,7 +726,7 @@ ___
 
 ▸ **parseAddress**(`addr`: string): *Buffer*
 
-*Defined in [apis/avm/api.ts:137](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L137)*
+*Defined in [apis/avm/api.ts:137](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L137)*
 
 Takes an address string and returns its [Buffer](https://github.com/feross/buffer) representation if valid.
 
@@ -744,7 +746,7 @@ ___
 
 ▸ **refreshBlockchainID**(`blockchainID`: string): *boolean*
 
-*Defined in [apis/avm/api.ts:120](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L120)*
+*Defined in [apis/avm/api.ts:120](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L120)*
 
 Refresh blockchainID, and if a blockchainID is passed in, use that.
 
@@ -764,7 +766,7 @@ ___
 
 ▸ **send**(`username`: string, `password`: string, `assetID`: string | Buffer, `amount`: number | BN, `to`: string, `from`: Array‹string› | Array‹Buffer›): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:746](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L746)*
+*Defined in [apis/avm/api.ts:750](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L750)*
 
 Sends an amount of assetID to the specified address from a list of owned of addresses.
 
@@ -791,7 +793,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 
@@ -809,7 +811,7 @@ ___
 
 ▸ **signMintTx**(`username`: string, `password`: string, `tx`: string | Buffer, `minter`: string): *Promise‹string›*
 
-*Defined in [apis/avm/api.ts:351](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L351)*
+*Defined in [apis/avm/api.ts:355](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L355)*
 
 Sign an unsigned or partially signed mint transaction.
 
@@ -832,7 +834,7 @@ ___
 
 ▸ **signTx**(`utx`: [UnsignedTx](_apis_avm_tx_.unsignedtx.md)): *[Tx](_apis_avm_tx_.tx.md)*
 
-*Defined in [apis/avm/api.ts:701](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L701)*
+*Defined in [apis/avm/api.ts:705](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L705)*
 
 Helper function which takes an unsigned transaction and signs it, returning the resulting [Tx](_apis_avm_tx_.tx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_api_.persistanceoptions.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_api_.persistanceoptions.md
@@ -32,7 +32,7 @@ A class for defining the persistance behavior of this an API call.
 
 \+ **new PersistanceOptions**(`name`: string, `overwrite`: boolean, `mergeRule`: [MergeRule](../modules/_apis_avm_types_.md#mergerule)): *[PersistanceOptions](_apis_avm_api_.persistanceoptions.md)*
 
-*Defined in [apis/avm/api.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L49)*
+*Defined in [apis/avm/api.ts:49](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L49)*
 
 **`remarks`** 
 The merge rules are as follows:
@@ -60,7 +60,7 @@ Name | Type | Default | Description |
 
 • **mergeRule**: *[MergeRule](../modules/_apis_avm_types_.md#mergerule)* = "union"
 
-*Defined in [apis/avm/api.ts:28](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L28)*
+*Defined in [apis/avm/api.ts:28](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L28)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **name**: *string* =  undefined
 
-*Defined in [apis/avm/api.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L26)*
+*Defined in [apis/avm/api.ts:26](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L26)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **overwrite**: *boolean* = false
 
-*Defined in [apis/avm/api.ts:27](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L27)*
+*Defined in [apis/avm/api.ts:27](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L27)*
 
 ## Methods
 
@@ -84,7 +84,7 @@ ___
 
 ▸ **getMergeRule**(): *[MergeRule](../modules/_apis_avm_types_.md#mergerule)*
 
-*Defined in [apis/avm/api.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L47)*
+*Defined in [apis/avm/api.ts:47](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L47)*
 
 Returns the [MergeRule](../modules/_apis_avm_types_.md#mergerule) of the instance
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **getName**(): *string*
 
-*Defined in [apis/avm/api.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L33)*
+*Defined in [apis/avm/api.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L33)*
 
 Returns the namespace of the instance
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **getOverwrite**(): *boolean*
 
-*Defined in [apis/avm/api.ts:40](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L40)*
+*Defined in [apis/avm/api.ts:40](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/api.ts#L40)*
 
 Returns the overwrite rule of the instance
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_api_.persistanceoptions.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_api_.persistanceoptions.md
@@ -32,7 +32,7 @@ A class for defining the persistance behavior of this an API call.
 
 \+ **new PersistanceOptions**(`name`: string, `overwrite`: boolean, `mergeRule`: [MergeRule](../modules/_apis_avm_types_.md#mergerule)): *[PersistanceOptions](_apis_avm_api_.persistanceoptions.md)*
 
-*Defined in [apis/avm/api.ts:49](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L49)*
+*Defined in [apis/avm/api.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L49)*
 
 **`remarks`** 
 The merge rules are as follows:
@@ -60,7 +60,7 @@ Name | Type | Default | Description |
 
 • **mergeRule**: *[MergeRule](../modules/_apis_avm_types_.md#mergerule)* = "union"
 
-*Defined in [apis/avm/api.ts:28](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L28)*
+*Defined in [apis/avm/api.ts:28](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L28)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **name**: *string* =  undefined
 
-*Defined in [apis/avm/api.ts:26](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L26)*
+*Defined in [apis/avm/api.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L26)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **overwrite**: *boolean* = false
 
-*Defined in [apis/avm/api.ts:27](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L27)*
+*Defined in [apis/avm/api.ts:27](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L27)*
 
 ## Methods
 
@@ -84,7 +84,7 @@ ___
 
 ▸ **getMergeRule**(): *[MergeRule](../modules/_apis_avm_types_.md#mergerule)*
 
-*Defined in [apis/avm/api.ts:47](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L47)*
+*Defined in [apis/avm/api.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L47)*
 
 Returns the [MergeRule](../modules/_apis_avm_types_.md#mergerule) of the instance
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **getName**(): *string*
 
-*Defined in [apis/avm/api.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L33)*
+*Defined in [apis/avm/api.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L33)*
 
 Returns the namespace of the instance
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **getOverwrite**(): *boolean*
 
-*Defined in [apis/avm/api.ts:40](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/api.ts#L40)*
+*Defined in [apis/avm/api.ts:40](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/api.ts#L40)*
 
 Returns the overwrite rule of the instance
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.credential.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.credential.md
@@ -33,7 +33,7 @@
 
 \+ **new Credential**(`sigarray`: Array‹[Signature](_apis_avm_types_.signature.md)›): *[Credential](_apis_avm_credentials_.credential.md)*
 
-*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L70)*
+*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L70)*
 
 **Parameters:**
 
@@ -49,7 +49,7 @@ Name | Type | Default |
 
 • **sigArray**: *Array‹[Signature](_apis_avm_types_.signature.md)›* =  []
 
-*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L35)*
+*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L35)*
 
 ## Methods
 
@@ -57,7 +57,7 @@ Name | Type | Default |
 
 ▸ **addSignature**(`sig`: [Signature](_apis_avm_types_.signature.md)): *number*
 
-*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L42)*
+*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L42)*
 
 Adds a signature to the credentials and returns the index off the added signature.
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: any, `offset`: number): *number*
 
-*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L47)*
+*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L47)*
 
 **Parameters:**
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **getCredentialID**(): *number*
 
-*Defined in [apis/avm/credentials.ts:37](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L37)*
+*Defined in [apis/avm/credentials.ts:37](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L37)*
 
 **Returns:** *number*
 
@@ -102,6 +102,6 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L59)*
+*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L59)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.credential.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.credential.md
@@ -33,7 +33,7 @@
 
 \+ **new Credential**(`sigarray`: Array‹[Signature](_apis_avm_types_.signature.md)›): *[Credential](_apis_avm_credentials_.credential.md)*
 
-*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L70)*
+*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L70)*
 
 **Parameters:**
 
@@ -49,7 +49,7 @@ Name | Type | Default |
 
 • **sigArray**: *Array‹[Signature](_apis_avm_types_.signature.md)›* =  []
 
-*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L35)*
+*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L35)*
 
 ## Methods
 
@@ -57,7 +57,7 @@ Name | Type | Default |
 
 ▸ **addSignature**(`sig`: [Signature](_apis_avm_types_.signature.md)): *number*
 
-*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L42)*
+*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L42)*
 
 Adds a signature to the credentials and returns the index off the added signature.
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: any, `offset`: number): *number*
 
-*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L47)*
+*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L47)*
 
 **Parameters:**
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **getCredentialID**(): *number*
 
-*Defined in [apis/avm/credentials.ts:37](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L37)*
+*Defined in [apis/avm/credentials.ts:37](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L37)*
 
 **Returns:** *number*
 
@@ -102,6 +102,6 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L59)*
+*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L59)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.nftcredential.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.nftcredential.md
@@ -33,7 +33,7 @@
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[constructor](_apis_avm_credentials_.credential.md#constructor)*
 
-*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L70)*
+*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L70)*
 
 **Parameters:**
 
@@ -51,7 +51,7 @@ Name | Type | Default |
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[sigArray](_apis_avm_credentials_.credential.md#protected-sigarray)*
 
-*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L35)*
+*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L35)*
 
 ## Methods
 
@@ -61,7 +61,7 @@ Name | Type | Default |
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md)*
 
-*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L42)*
+*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L42)*
 
 Adds a signature to the credentials and returns the index off the added signature.
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[fromBuffer](_apis_avm_credentials_.credential.md#frombuffer)*
 
-*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L47)*
+*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L47)*
 
 **Parameters:**
 
@@ -100,7 +100,7 @@ ___
 
 *Overrides [Credential](_apis_avm_credentials_.credential.md).[getCredentialID](_apis_avm_credentials_.credential.md#abstract-getcredentialid)*
 
-*Defined in [apis/avm/credentials.ts:90](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L90)*
+*Defined in [apis/avm/credentials.ts:90](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L90)*
 
 **Returns:** *number*
 
@@ -112,6 +112,6 @@ ___
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[toBuffer](_apis_avm_credentials_.credential.md#tobuffer)*
 
-*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L59)*
+*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L59)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.nftcredential.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.nftcredential.md
@@ -33,7 +33,7 @@
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[constructor](_apis_avm_credentials_.credential.md#constructor)*
 
-*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L70)*
+*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L70)*
 
 **Parameters:**
 
@@ -51,7 +51,7 @@ Name | Type | Default |
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[sigArray](_apis_avm_credentials_.credential.md#protected-sigarray)*
 
-*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L35)*
+*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L35)*
 
 ## Methods
 
@@ -61,7 +61,7 @@ Name | Type | Default |
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md)*
 
-*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L42)*
+*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L42)*
 
 Adds a signature to the credentials and returns the index off the added signature.
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[fromBuffer](_apis_avm_credentials_.credential.md#frombuffer)*
 
-*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L47)*
+*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L47)*
 
 **Parameters:**
 
@@ -100,7 +100,7 @@ ___
 
 *Overrides [Credential](_apis_avm_credentials_.credential.md).[getCredentialID](_apis_avm_credentials_.credential.md#abstract-getcredentialid)*
 
-*Defined in [apis/avm/credentials.ts:90](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L90)*
+*Defined in [apis/avm/credentials.ts:90](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L90)*
 
 **Returns:** *number*
 
@@ -112,6 +112,6 @@ ___
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[toBuffer](_apis_avm_credentials_.credential.md#tobuffer)*
 
-*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L59)*
+*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L59)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.secpcredential.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.secpcredential.md
@@ -33,7 +33,7 @@
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[constructor](_apis_avm_credentials_.credential.md#constructor)*
 
-*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L70)*
+*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L70)*
 
 **Parameters:**
 
@@ -51,7 +51,7 @@ Name | Type | Default |
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[sigArray](_apis_avm_credentials_.credential.md#protected-sigarray)*
 
-*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L35)*
+*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L35)*
 
 ## Methods
 
@@ -61,7 +61,7 @@ Name | Type | Default |
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md)*
 
-*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L42)*
+*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L42)*
 
 Adds a signature to the credentials and returns the index off the added signature.
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[fromBuffer](_apis_avm_credentials_.credential.md#frombuffer)*
 
-*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L47)*
+*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L47)*
 
 **Parameters:**
 
@@ -100,7 +100,7 @@ ___
 
 *Overrides [Credential](_apis_avm_credentials_.credential.md).[getCredentialID](_apis_avm_credentials_.credential.md#abstract-getcredentialid)*
 
-*Defined in [apis/avm/credentials.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L82)*
+*Defined in [apis/avm/credentials.ts:82](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L82)*
 
 **Returns:** *number*
 
@@ -112,6 +112,6 @@ ___
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[toBuffer](_apis_avm_credentials_.credential.md#tobuffer)*
 
-*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L59)*
+*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L59)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.secpcredential.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_credentials_.secpcredential.md
@@ -33,7 +33,7 @@
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[constructor](_apis_avm_credentials_.credential.md#constructor)*
 
-*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L70)*
+*Defined in [apis/avm/credentials.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L70)*
 
 **Parameters:**
 
@@ -51,7 +51,7 @@ Name | Type | Default |
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[sigArray](_apis_avm_credentials_.credential.md#protected-sigarray)*
 
-*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L35)*
+*Defined in [apis/avm/credentials.ts:35](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L35)*
 
 ## Methods
 
@@ -61,7 +61,7 @@ Name | Type | Default |
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md)*
 
-*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L42)*
+*Defined in [apis/avm/credentials.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L42)*
 
 Adds a signature to the credentials and returns the index off the added signature.
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[fromBuffer](_apis_avm_credentials_.credential.md#frombuffer)*
 
-*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L47)*
+*Defined in [apis/avm/credentials.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L47)*
 
 **Parameters:**
 
@@ -100,7 +100,7 @@ ___
 
 *Overrides [Credential](_apis_avm_credentials_.credential.md).[getCredentialID](_apis_avm_credentials_.credential.md#abstract-getcredentialid)*
 
-*Defined in [apis/avm/credentials.ts:82](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L82)*
+*Defined in [apis/avm/credentials.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L82)*
 
 **Returns:** *number*
 
@@ -112,6 +112,6 @@ ___
 
 *Inherited from [Credential](_apis_avm_credentials_.credential.md).[toBuffer](_apis_avm_credentials_.credential.md#tobuffer)*
 
-*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L59)*
+*Defined in [apis/avm/credentials.ts:59](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L59)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.amountinput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.amountinput.md
@@ -45,7 +45,7 @@ An [Input](_apis_avm_inputs_.input.md) class which specifies a token amount .
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[constructor](_apis_avm_inputs_.input.md#constructor)*
 
-*Defined in [apis/avm/inputs.ts:262](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L262)*
+*Defined in [apis/avm/inputs.ts:262](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L262)*
 
 An [AmountInput](_apis_avm_inputs_.amountinput.md) class which issues a payment on an assetID.
 
@@ -63,7 +63,7 @@ Name | Type | Default | Description |
 
 • **amount**: *Buffer* =  Buffer.alloc(8)
 
-*Defined in [apis/avm/inputs.ts:234](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L234)*
+*Defined in [apis/avm/inputs.ts:234](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L234)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 • **amountValue**: *BN* =  new BN(0)
 
-*Defined in [apis/avm/inputs.ts:235](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L235)*
+*Defined in [apis/avm/inputs.ts:235](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L235)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[sigCount](_apis_avm_inputs_.input.md#protected-sigcount)*
 
-*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L31)*
+*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L31)*
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[sigIdxs](_apis_avm_inputs_.input.md#protected-sigidxs)*
 
-*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L32)*
+*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L32)*
 
 ## Methods
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L53)*
+*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Input](_apis_avm_inputs_.input.md).
 
@@ -122,7 +122,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[fromBuffer](_apis_avm_inputs_.input.md#frombuffer)*
 
-*Defined in [apis/avm/inputs.ts:247](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L247)*
+*Defined in [apis/avm/inputs.ts:247](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L247)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [AmountInput](_apis_avm_inputs_.amountinput.md) and returns the size of the output.
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **getAmount**(): *BN*
 
-*Defined in [apis/avm/inputs.ts:240](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L240)*
+*Defined in [apis/avm/inputs.ts:240](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L240)*
 
 Returns the amount as a [BN](https://github.com/indutny/bn.js/).
 
@@ -155,7 +155,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L43)*
+*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L43)*
 
 **Returns:** *number*
 
@@ -167,7 +167,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[getInputID](_apis_avm_inputs_.input.md#abstract-getinputid)*
 
-*Defined in [apis/avm/inputs.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L34)*
+*Defined in [apis/avm/inputs.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L34)*
 
 **Returns:** *number*
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L39)*
+*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Input](_apis_avm_inputs_.input.md)
 
@@ -193,7 +193,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[toBuffer](_apis_avm_inputs_.input.md#tobuffer)*
 
-*Defined in [apis/avm/inputs.ts:257](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L257)*
+*Defined in [apis/avm/inputs.ts:257](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L257)*
 
 Returns the buffer representing the [AmountInput](_apis_avm_inputs_.amountinput.md) instance.
 
@@ -207,7 +207,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[toString](_apis_avm_inputs_.input.md#tostring)*
 
-*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L93)*
+*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L93)*
 
 Returns a base-58 representation of the [Input](_apis_avm_inputs_.input.md).
 
@@ -221,7 +221,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L97)*
+*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L97)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.amountinput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.amountinput.md
@@ -45,7 +45,7 @@ An [Input](_apis_avm_inputs_.input.md) class which specifies a token amount .
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[constructor](_apis_avm_inputs_.input.md#constructor)*
 
-*Defined in [apis/avm/inputs.ts:262](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L262)*
+*Defined in [apis/avm/inputs.ts:262](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L262)*
 
 An [AmountInput](_apis_avm_inputs_.amountinput.md) class which issues a payment on an assetID.
 
@@ -63,7 +63,7 @@ Name | Type | Default | Description |
 
 • **amount**: *Buffer* =  Buffer.alloc(8)
 
-*Defined in [apis/avm/inputs.ts:234](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L234)*
+*Defined in [apis/avm/inputs.ts:234](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L234)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 • **amountValue**: *BN* =  new BN(0)
 
-*Defined in [apis/avm/inputs.ts:235](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L235)*
+*Defined in [apis/avm/inputs.ts:235](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L235)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[sigCount](_apis_avm_inputs_.input.md#protected-sigcount)*
 
-*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L31)*
+*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L31)*
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[sigIdxs](_apis_avm_inputs_.input.md#protected-sigidxs)*
 
-*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L32)*
+*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L32)*
 
 ## Methods
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L53)*
+*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Input](_apis_avm_inputs_.input.md).
 
@@ -122,7 +122,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[fromBuffer](_apis_avm_inputs_.input.md#frombuffer)*
 
-*Defined in [apis/avm/inputs.ts:247](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L247)*
+*Defined in [apis/avm/inputs.ts:247](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L247)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [AmountInput](_apis_avm_inputs_.amountinput.md) and returns the size of the output.
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **getAmount**(): *BN*
 
-*Defined in [apis/avm/inputs.ts:240](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L240)*
+*Defined in [apis/avm/inputs.ts:240](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L240)*
 
 Returns the amount as a [BN](https://github.com/indutny/bn.js/).
 
@@ -155,7 +155,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L43)*
+*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L43)*
 
 **Returns:** *number*
 
@@ -167,7 +167,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[getInputID](_apis_avm_inputs_.input.md#abstract-getinputid)*
 
-*Defined in [apis/avm/inputs.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L34)*
+*Defined in [apis/avm/inputs.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L34)*
 
 **Returns:** *number*
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L39)*
+*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Input](_apis_avm_inputs_.input.md)
 
@@ -193,7 +193,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[toBuffer](_apis_avm_inputs_.input.md#tobuffer)*
 
-*Defined in [apis/avm/inputs.ts:257](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L257)*
+*Defined in [apis/avm/inputs.ts:257](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L257)*
 
 Returns the buffer representing the [AmountInput](_apis_avm_inputs_.amountinput.md) instance.
 
@@ -207,7 +207,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[toString](_apis_avm_inputs_.input.md#tostring)*
 
-*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L93)*
+*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L93)*
 
 Returns a base-58 representation of the [Input](_apis_avm_inputs_.input.md).
 
@@ -221,7 +221,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L97)*
+*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L97)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.input.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.input.md
@@ -36,7 +36,7 @@
 
 \+ **new Input**(): *[Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:111](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L111)*
+*Defined in [apis/avm/inputs.ts:111](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L111)*
 
 **Returns:** *[Input](_apis_avm_inputs_.input.md)*
 
@@ -46,7 +46,7 @@
 
 • **sigCount**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L31)*
+*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L31)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • **sigIdxs**: *Array‹[SigIdx](_apis_avm_types_.sigidx.md)›* =  []
 
-*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L32)*
+*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L32)*
 
 ## Methods
 
@@ -62,7 +62,7 @@ ___
 
 ▸ **addSignatureIdx**(`addressIdx`: number, `address`: Buffer): *void*
 
-*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L53)*
+*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Input](_apis_avm_inputs_.input.md).
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/inputs.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L63)*
+*Defined in [apis/avm/inputs.ts:63](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L63)*
 
 **Parameters:**
 
@@ -98,7 +98,7 @@ ___
 
 ▸ **getCredentialID**(): *number*
 
-*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L43)*
+*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L43)*
 
 **Returns:** *number*
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **getInputID**(): *number*
 
-*Defined in [apis/avm/inputs.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L34)*
+*Defined in [apis/avm/inputs.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L34)*
 
 **Returns:** *number*
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **getSigIdxs**(): *Array‹[SigIdx](_apis_avm_types_.sigidx.md)›*
 
-*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L39)*
+*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Input](_apis_avm_inputs_.input.md)
 
@@ -130,7 +130,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:78](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L78)*
+*Defined in [apis/avm/inputs.ts:78](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L78)*
 
 **Returns:** *Buffer*
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L93)*
+*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L93)*
 
 Returns a base-58 representation of the [Input](_apis_avm_inputs_.input.md).
 
@@ -152,7 +152,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L97)*
+*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L97)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.input.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.input.md
@@ -36,7 +36,7 @@
 
 \+ **new Input**(): *[Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:111](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L111)*
+*Defined in [apis/avm/inputs.ts:111](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L111)*
 
 **Returns:** *[Input](_apis_avm_inputs_.input.md)*
 
@@ -46,7 +46,7 @@
 
 • **sigCount**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L31)*
+*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L31)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • **sigIdxs**: *Array‹[SigIdx](_apis_avm_types_.sigidx.md)›* =  []
 
-*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L32)*
+*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L32)*
 
 ## Methods
 
@@ -62,7 +62,7 @@ ___
 
 ▸ **addSignatureIdx**(`addressIdx`: number, `address`: Buffer): *void*
 
-*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L53)*
+*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Input](_apis_avm_inputs_.input.md).
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/inputs.ts:63](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L63)*
+*Defined in [apis/avm/inputs.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L63)*
 
 **Parameters:**
 
@@ -98,7 +98,7 @@ ___
 
 ▸ **getCredentialID**(): *number*
 
-*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L43)*
+*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L43)*
 
 **Returns:** *number*
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **getInputID**(): *number*
 
-*Defined in [apis/avm/inputs.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L34)*
+*Defined in [apis/avm/inputs.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L34)*
 
 **Returns:** *number*
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **getSigIdxs**(): *Array‹[SigIdx](_apis_avm_types_.sigidx.md)›*
 
-*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L39)*
+*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Input](_apis_avm_inputs_.input.md)
 
@@ -130,7 +130,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:78](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L78)*
+*Defined in [apis/avm/inputs.ts:78](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L78)*
 
 **Returns:** *Buffer*
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L93)*
+*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L93)*
 
 Returns a base-58 representation of the [Input](_apis_avm_inputs_.input.md).
 
@@ -152,7 +152,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L97)*
+*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L97)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.secpinput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.secpinput.md
@@ -43,7 +43,7 @@
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[constructor](_apis_avm_inputs_.input.md#constructor)*
 
-*Defined in [apis/avm/inputs.ts:262](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L262)*
+*Defined in [apis/avm/inputs.ts:262](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L262)*
 
 An [AmountInput](_apis_avm_inputs_.amountinput.md) class which issues a payment on an assetID.
 
@@ -63,7 +63,7 @@ Name | Type | Default | Description |
 
 *Inherited from [AmountInput](_apis_avm_inputs_.amountinput.md).[amount](_apis_avm_inputs_.amountinput.md#protected-amount)*
 
-*Defined in [apis/avm/inputs.ts:234](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L234)*
+*Defined in [apis/avm/inputs.ts:234](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L234)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 *Inherited from [AmountInput](_apis_avm_inputs_.amountinput.md).[amountValue](_apis_avm_inputs_.amountinput.md#protected-amountvalue)*
 
-*Defined in [apis/avm/inputs.ts:235](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L235)*
+*Defined in [apis/avm/inputs.ts:235](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L235)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[sigCount](_apis_avm_inputs_.input.md#protected-sigcount)*
 
-*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L31)*
+*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L31)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[sigIdxs](_apis_avm_inputs_.input.md#protected-sigidxs)*
 
-*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L32)*
+*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L32)*
 
 ## Methods
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L53)*
+*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Input](_apis_avm_inputs_.input.md).
 
@@ -126,7 +126,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[fromBuffer](_apis_avm_inputs_.input.md#frombuffer)*
 
-*Defined in [apis/avm/inputs.ts:247](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L247)*
+*Defined in [apis/avm/inputs.ts:247](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L247)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [AmountInput](_apis_avm_inputs_.amountinput.md) and returns the size of the output.
 
@@ -147,7 +147,7 @@ ___
 
 *Inherited from [AmountInput](_apis_avm_inputs_.amountinput.md)*
 
-*Defined in [apis/avm/inputs.ts:240](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L240)*
+*Defined in [apis/avm/inputs.ts:240](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L240)*
 
 Returns the amount as a [BN](https://github.com/indutny/bn.js/).
 
@@ -161,7 +161,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L43)*
+*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L43)*
 
 **Returns:** *number*
 
@@ -173,7 +173,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[getInputID](_apis_avm_inputs_.input.md#abstract-getinputid)*
 
-*Defined in [apis/avm/inputs.ts:282](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L282)*
+*Defined in [apis/avm/inputs.ts:282](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L282)*
 
 Returns the inputID for this input
 
@@ -187,7 +187,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L39)*
+*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Input](_apis_avm_inputs_.input.md)
 
@@ -203,7 +203,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[toBuffer](_apis_avm_inputs_.input.md#tobuffer)*
 
-*Defined in [apis/avm/inputs.ts:257](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L257)*
+*Defined in [apis/avm/inputs.ts:257](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L257)*
 
 Returns the buffer representing the [AmountInput](_apis_avm_inputs_.amountinput.md) instance.
 
@@ -217,7 +217,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[toString](_apis_avm_inputs_.input.md#tostring)*
 
-*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L93)*
+*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L93)*
 
 Returns a base-58 representation of the [Input](_apis_avm_inputs_.input.md).
 
@@ -231,7 +231,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L97)*
+*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L97)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.secpinput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.secpinput.md
@@ -43,7 +43,7 @@
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[constructor](_apis_avm_inputs_.input.md#constructor)*
 
-*Defined in [apis/avm/inputs.ts:262](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L262)*
+*Defined in [apis/avm/inputs.ts:262](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L262)*
 
 An [AmountInput](_apis_avm_inputs_.amountinput.md) class which issues a payment on an assetID.
 
@@ -63,7 +63,7 @@ Name | Type | Default | Description |
 
 *Inherited from [AmountInput](_apis_avm_inputs_.amountinput.md).[amount](_apis_avm_inputs_.amountinput.md#protected-amount)*
 
-*Defined in [apis/avm/inputs.ts:234](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L234)*
+*Defined in [apis/avm/inputs.ts:234](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L234)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 *Inherited from [AmountInput](_apis_avm_inputs_.amountinput.md).[amountValue](_apis_avm_inputs_.amountinput.md#protected-amountvalue)*
 
-*Defined in [apis/avm/inputs.ts:235](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L235)*
+*Defined in [apis/avm/inputs.ts:235](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L235)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[sigCount](_apis_avm_inputs_.input.md#protected-sigcount)*
 
-*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L31)*
+*Defined in [apis/avm/inputs.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L31)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[sigIdxs](_apis_avm_inputs_.input.md#protected-sigidxs)*
 
-*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L32)*
+*Defined in [apis/avm/inputs.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L32)*
 
 ## Methods
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L53)*
+*Defined in [apis/avm/inputs.ts:53](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Input](_apis_avm_inputs_.input.md).
 
@@ -126,7 +126,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[fromBuffer](_apis_avm_inputs_.input.md#frombuffer)*
 
-*Defined in [apis/avm/inputs.ts:247](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L247)*
+*Defined in [apis/avm/inputs.ts:247](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L247)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [AmountInput](_apis_avm_inputs_.amountinput.md) and returns the size of the output.
 
@@ -147,7 +147,7 @@ ___
 
 *Inherited from [AmountInput](_apis_avm_inputs_.amountinput.md)*
 
-*Defined in [apis/avm/inputs.ts:240](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L240)*
+*Defined in [apis/avm/inputs.ts:240](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L240)*
 
 Returns the amount as a [BN](https://github.com/indutny/bn.js/).
 
@@ -161,7 +161,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L43)*
+*Defined in [apis/avm/inputs.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L43)*
 
 **Returns:** *number*
 
@@ -173,7 +173,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[getInputID](_apis_avm_inputs_.input.md#abstract-getinputid)*
 
-*Defined in [apis/avm/inputs.ts:282](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L282)*
+*Defined in [apis/avm/inputs.ts:282](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L282)*
 
 Returns the inputID for this input
 
@@ -187,7 +187,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L39)*
+*Defined in [apis/avm/inputs.ts:39](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Input](_apis_avm_inputs_.input.md)
 
@@ -203,7 +203,7 @@ ___
 
 *Overrides [Input](_apis_avm_inputs_.input.md).[toBuffer](_apis_avm_inputs_.input.md#tobuffer)*
 
-*Defined in [apis/avm/inputs.ts:257](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L257)*
+*Defined in [apis/avm/inputs.ts:257](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L257)*
 
 Returns the buffer representing the [AmountInput](_apis_avm_inputs_.amountinput.md) instance.
 
@@ -217,7 +217,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md).[toString](_apis_avm_inputs_.input.md#tostring)*
 
-*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L93)*
+*Defined in [apis/avm/inputs.ts:93](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L93)*
 
 Returns a base-58 representation of the [Input](_apis_avm_inputs_.input.md).
 
@@ -231,7 +231,7 @@ ___
 
 *Inherited from [Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L97)*
+*Defined in [apis/avm/inputs.ts:97](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L97)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.transferableinput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.transferableinput.md
@@ -37,7 +37,7 @@
 
 \+ **new TransferableInput**(`txid`: Buffer, `outputidx`: Buffer, `assetID`: Buffer, `input`: [Input](_apis_avm_inputs_.input.md)): *[TransferableInput](_apis_avm_inputs_.transferableinput.md)*
 
-*Defined in [apis/avm/inputs.ts:210](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L210)*
+*Defined in [apis/avm/inputs.ts:210](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L210)*
 
 Class representing an [TransferableInput](_apis_avm_inputs_.transferableinput.md) for a transaction.
 
@@ -58,7 +58,7 @@ Name | Type | Default | Description |
 
 • **assetid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/inputs.ts:120](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L120)*
+*Defined in [apis/avm/inputs.ts:120](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L120)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • **input**: *[Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:121](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L121)*
+*Defined in [apis/avm/inputs.ts:121](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L121)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 • **outputidx**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/inputs.ts:119](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L119)*
+*Defined in [apis/avm/inputs.ts:119](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L119)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • **txid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/inputs.ts:118](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L118)*
+*Defined in [apis/avm/inputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L118)*
 
 ## Methods
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/inputs.ts:178](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L178)*
+*Defined in [apis/avm/inputs.ts:178](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L178)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [TransferableInput](_apis_avm_inputs_.transferableinput.md), parses it, populates the class, and returns the length of the [TransferableInput](_apis_avm_inputs_.transferableinput.md) in bytes.
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **getAssetID**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:167](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L167)*
+*Defined in [apis/avm/inputs.ts:167](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L167)*
 
 Returns the assetID of the input.
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **getInput**(): *[Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:160](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L160)*
+*Defined in [apis/avm/inputs.ts:160](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L160)*
 
 Returns the input.
 
@@ -135,7 +135,7 @@ ___
 
 ▸ **getOutputIdx**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:145](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L145)*
+*Defined in [apis/avm/inputs.ts:145](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L145)*
 
 Returns a [Buffer](https://github.com/feross/buffer)  of the OutputIdx.
 
@@ -147,7 +147,7 @@ ___
 
 ▸ **getTxID**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:137](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L137)*
+*Defined in [apis/avm/inputs.ts:137](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L137)*
 
 Returns a [Buffer](https://github.com/feross/buffer) of the TxID.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **getUTXOID**(): *string*
 
-*Defined in [apis/avm/inputs.ts:153](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L153)*
+*Defined in [apis/avm/inputs.ts:153](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L153)*
 
 Returns a base-58 string representation of the UTXOID this [TransferableInput](_apis_avm_inputs_.transferableinput.md) references.
 
@@ -171,7 +171,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:194](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L194)*
+*Defined in [apis/avm/inputs.ts:194](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L194)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [TransferableInput](_apis_avm_inputs_.transferableinput.md).
 
@@ -183,7 +183,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/inputs.ts:207](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L207)*
+*Defined in [apis/avm/inputs.ts:207](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L207)*
 
 Returns a base-58 representation of the [TransferableInput](_apis_avm_inputs_.transferableinput.md).
 
@@ -195,7 +195,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/inputs.ts:126](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L126)*
+*Defined in [apis/avm/inputs.ts:126](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L126)*
 
 Returns a function used to sort an array of [TransferableInput](_apis_avm_inputs_.transferableinput.md)s
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.transferableinput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_inputs_.transferableinput.md
@@ -37,7 +37,7 @@
 
 \+ **new TransferableInput**(`txid`: Buffer, `outputidx`: Buffer, `assetID`: Buffer, `input`: [Input](_apis_avm_inputs_.input.md)): *[TransferableInput](_apis_avm_inputs_.transferableinput.md)*
 
-*Defined in [apis/avm/inputs.ts:210](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L210)*
+*Defined in [apis/avm/inputs.ts:210](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L210)*
 
 Class representing an [TransferableInput](_apis_avm_inputs_.transferableinput.md) for a transaction.
 
@@ -58,7 +58,7 @@ Name | Type | Default | Description |
 
 • **assetid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/inputs.ts:120](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L120)*
+*Defined in [apis/avm/inputs.ts:120](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L120)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • **input**: *[Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:121](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L121)*
+*Defined in [apis/avm/inputs.ts:121](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L121)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 • **outputidx**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/inputs.ts:119](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L119)*
+*Defined in [apis/avm/inputs.ts:119](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L119)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • **txid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/inputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L118)*
+*Defined in [apis/avm/inputs.ts:118](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L118)*
 
 ## Methods
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/inputs.ts:178](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L178)*
+*Defined in [apis/avm/inputs.ts:178](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L178)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [TransferableInput](_apis_avm_inputs_.transferableinput.md), parses it, populates the class, and returns the length of the [TransferableInput](_apis_avm_inputs_.transferableinput.md) in bytes.
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **getAssetID**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:167](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L167)*
+*Defined in [apis/avm/inputs.ts:167](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L167)*
 
 Returns the assetID of the input.
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **getInput**(): *[Input](_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:160](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L160)*
+*Defined in [apis/avm/inputs.ts:160](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L160)*
 
 Returns the input.
 
@@ -135,7 +135,7 @@ ___
 
 ▸ **getOutputIdx**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:145](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L145)*
+*Defined in [apis/avm/inputs.ts:145](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L145)*
 
 Returns a [Buffer](https://github.com/feross/buffer)  of the OutputIdx.
 
@@ -147,7 +147,7 @@ ___
 
 ▸ **getTxID**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:137](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L137)*
+*Defined in [apis/avm/inputs.ts:137](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L137)*
 
 Returns a [Buffer](https://github.com/feross/buffer) of the TxID.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **getUTXOID**(): *string*
 
-*Defined in [apis/avm/inputs.ts:153](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L153)*
+*Defined in [apis/avm/inputs.ts:153](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L153)*
 
 Returns a base-58 string representation of the UTXOID this [TransferableInput](_apis_avm_inputs_.transferableinput.md) references.
 
@@ -171,7 +171,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/inputs.ts:194](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L194)*
+*Defined in [apis/avm/inputs.ts:194](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L194)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [TransferableInput](_apis_avm_inputs_.transferableinput.md).
 
@@ -183,7 +183,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/inputs.ts:207](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L207)*
+*Defined in [apis/avm/inputs.ts:207](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L207)*
 
 Returns a base-58 representation of the [TransferableInput](_apis_avm_inputs_.transferableinput.md).
 
@@ -195,7 +195,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/inputs.ts:126](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L126)*
+*Defined in [apis/avm/inputs.ts:126](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L126)*
 
 Returns a function used to sort an array of [TransferableInput](_apis_avm_inputs_.transferableinput.md)s
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_keychain_.avmkeychain.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_keychain_.avmkeychain.md
@@ -45,7 +45,7 @@ Class for representing a key chain in Slopes.
 
 *Overrides [KeyChain](_utils_types_.keychain.md).[constructor](_utils_types_.keychain.md#constructor)*
 
-*Defined in [apis/avm/keychain.ts:255](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L255)*
+*Defined in [apis/avm/keychain.ts:255](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L255)*
 
 Returns instance of AVMKeyChain.
 
@@ -65,7 +65,7 @@ Name | Type |
 
 *Inherited from [KeyChain](_utils_types_.keychain.md).[chainid](_utils_types_.keychain.md#protected-chainid)*
 
-*Defined in [utils/types.ts:272](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L272)*
+*Defined in [utils/types.ts:272](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L272)*
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md).[keys](_utils_types_.keychain.md#protected-keys)*
 
-*Defined in [utils/types.ts:271](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L271)*
+*Defined in [utils/types.ts:271](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L271)*
 
 #### Type declaration:
 
@@ -89,7 +89,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:315](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L315)*
+*Defined in [utils/types.ts:315](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L315)*
 
 Adds the key pair to the list of the keys managed in the [KeyChain](_utils_types_.keychain.md).
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:306](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L306)*
+*Defined in [utils/types.ts:306](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L306)*
 
 Gets an array of addresses stored in the [KeyChain](_utils_types_.keychain.md).
 
@@ -125,7 +125,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:297](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L297)*
+*Defined in [utils/types.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L297)*
 
 Gets an array of addresses stored in the [KeyChain](_utils_types_.keychain.md).
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:369](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L369)*
+*Defined in [utils/types.ts:369](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L369)*
 
 Returns the chainID associated with this [KeyChain](_utils_types_.keychain.md).
 
@@ -157,7 +157,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:360](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L360)*
+*Defined in [utils/types.ts:360](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L360)*
 
 Returns the [KeyPair](_utils_types_.keypair.md) listed under the provided address
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:349](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L349)*
+*Defined in [utils/types.ts:349](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L349)*
 
 Checks if there is a key associated with the provided address.
 
@@ -201,7 +201,7 @@ ___
 
 *Overrides [KeyChain](_utils_types_.keychain.md).[importKey](_utils_types_.keychain.md#importkey)*
 
-*Defined in [apis/avm/keychain.ts:230](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L230)*
+*Defined in [apis/avm/keychain.ts:230](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L230)*
 
 Given a private key, makes a new key pair, returns the address.
 
@@ -223,7 +223,7 @@ ___
 
 *Overrides [KeyChain](_utils_types_.keychain.md).[makeKey](_utils_types_.keychain.md#makekey)*
 
-*Defined in [apis/avm/keychain.ts:217](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L217)*
+*Defined in [apis/avm/keychain.ts:217](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L217)*
 
 Makes a new key pair, returns the address.
 
@@ -245,7 +245,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:327](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L327)*
+*Defined in [utils/types.ts:327](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L327)*
 
 Removes the key pair from the list of they keys managed in the [KeyChain](_utils_types_.keychain.md).
 
@@ -267,7 +267,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:378](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L378)*
+*Defined in [utils/types.ts:378](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L378)*
 
 Sets the the chainID associated with this [KeyChain](_utils_types_.keychain.md) and all associated keypairs.
 
@@ -285,7 +285,7 @@ ___
 
 ▸ **signTx**(`utx`: [UnsignedTx](_apis_avm_tx_.unsignedtx.md)): *[Tx](_apis_avm_tx_.tx.md)*
 
-*Defined in [apis/avm/keychain.ts:253](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L253)*
+*Defined in [apis/avm/keychain.ts:253](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L253)*
 
 DEPRECATED: use UnsignedTx.sign(keychain) instead
 Signs a [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns signed [Tx](_apis_avm_tx_.tx.md)

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_keychain_.avmkeychain.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_keychain_.avmkeychain.md
@@ -45,7 +45,7 @@ Class for representing a key chain in Slopes.
 
 *Overrides [KeyChain](_utils_types_.keychain.md).[constructor](_utils_types_.keychain.md#constructor)*
 
-*Defined in [apis/avm/keychain.ts:255](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L255)*
+*Defined in [apis/avm/keychain.ts:255](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L255)*
 
 Returns instance of AVMKeyChain.
 
@@ -65,7 +65,7 @@ Name | Type |
 
 *Inherited from [KeyChain](_utils_types_.keychain.md).[chainid](_utils_types_.keychain.md#protected-chainid)*
 
-*Defined in [utils/types.ts:272](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L272)*
+*Defined in [utils/types.ts:272](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L272)*
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md).[keys](_utils_types_.keychain.md#protected-keys)*
 
-*Defined in [utils/types.ts:271](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L271)*
+*Defined in [utils/types.ts:271](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L271)*
 
 #### Type declaration:
 
@@ -89,7 +89,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:315](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L315)*
+*Defined in [utils/types.ts:315](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L315)*
 
 Adds the key pair to the list of the keys managed in the [KeyChain](_utils_types_.keychain.md).
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:306](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L306)*
+*Defined in [utils/types.ts:306](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L306)*
 
 Gets an array of addresses stored in the [KeyChain](_utils_types_.keychain.md).
 
@@ -125,7 +125,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L297)*
+*Defined in [utils/types.ts:297](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L297)*
 
 Gets an array of addresses stored in the [KeyChain](_utils_types_.keychain.md).
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:369](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L369)*
+*Defined in [utils/types.ts:369](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L369)*
 
 Returns the chainID associated with this [KeyChain](_utils_types_.keychain.md).
 
@@ -157,7 +157,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:360](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L360)*
+*Defined in [utils/types.ts:360](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L360)*
 
 Returns the [KeyPair](_utils_types_.keypair.md) listed under the provided address
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:349](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L349)*
+*Defined in [utils/types.ts:349](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L349)*
 
 Checks if there is a key associated with the provided address.
 
@@ -201,7 +201,7 @@ ___
 
 *Overrides [KeyChain](_utils_types_.keychain.md).[importKey](_utils_types_.keychain.md#importkey)*
 
-*Defined in [apis/avm/keychain.ts:230](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L230)*
+*Defined in [apis/avm/keychain.ts:230](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L230)*
 
 Given a private key, makes a new key pair, returns the address.
 
@@ -223,7 +223,7 @@ ___
 
 *Overrides [KeyChain](_utils_types_.keychain.md).[makeKey](_utils_types_.keychain.md#makekey)*
 
-*Defined in [apis/avm/keychain.ts:217](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L217)*
+*Defined in [apis/avm/keychain.ts:217](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L217)*
 
 Makes a new key pair, returns the address.
 
@@ -245,7 +245,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:327](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L327)*
+*Defined in [utils/types.ts:327](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L327)*
 
 Removes the key pair from the list of they keys managed in the [KeyChain](_utils_types_.keychain.md).
 
@@ -267,7 +267,7 @@ ___
 
 *Inherited from [KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:378](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L378)*
+*Defined in [utils/types.ts:378](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L378)*
 
 Sets the the chainID associated with this [KeyChain](_utils_types_.keychain.md) and all associated keypairs.
 
@@ -285,7 +285,7 @@ ___
 
 ▸ **signTx**(`utx`: [UnsignedTx](_apis_avm_tx_.unsignedtx.md)): *[Tx](_apis_avm_tx_.tx.md)*
 
-*Defined in [apis/avm/keychain.ts:253](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L253)*
+*Defined in [apis/avm/keychain.ts:253](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L253)*
 
 DEPRECATED: use UnsignedTx.sign(keychain) instead
 Signs a [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns signed [Tx](_apis_avm_tx_.tx.md)

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_keychain_.avmkeypair.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_keychain_.avmkeypair.md
@@ -48,7 +48,7 @@ Class for representing a private and public keypair in the AVM.
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[constructor](_utils_types_.keypair.md#constructor)*
 
-*Defined in [apis/avm/keychain.ts:191](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L191)*
+*Defined in [apis/avm/keychain.ts:191](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L191)*
 
 Class for representing a private and public keypair in Slopes.
 
@@ -69,7 +69,7 @@ Name | Type | Default |
 
 *Inherited from [KeyPair](_utils_types_.keypair.md).[chainid](_utils_types_.keypair.md#protected-chainid)*
 
-*Defined in [utils/types.ts:148](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L148)*
+*Defined in [utils/types.ts:148](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L148)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **keypair**: *elliptic.ec.KeyPair*
 
-*Defined in [apis/avm/keychain.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L43)*
+*Defined in [apis/avm/keychain.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L43)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md).[privk](_utils_types_.keypair.md#protected-privk)*
 
-*Defined in [utils/types.ts:147](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L147)*
+*Defined in [utils/types.ts:147](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L147)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md).[pubk](_utils_types_.keypair.md#protected-pubk)*
 
-*Defined in [utils/types.ts:146](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L146)*
+*Defined in [utils/types.ts:146](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L146)*
 
 ## Methods
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **addressFromPublicKey**(`pubk`: Buffer): *Buffer*
 
-*Defined in [apis/avm/keychain.ts:114](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L114)*
+*Defined in [apis/avm/keychain.ts:114](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L114)*
 
 Returns an address given a public key.
 
@@ -127,7 +127,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[generateKey](_utils_types_.keypair.md#generatekey)*
 
-*Defined in [apis/avm/keychain.ts:65](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L65)*
+*Defined in [apis/avm/keychain.ts:65](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L65)*
 
 Generates a new keypair.
 
@@ -147,7 +147,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[getAddress](_utils_types_.keypair.md#getaddress)*
 
-*Defined in [apis/avm/keychain.ts:93](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L93)*
+*Defined in [apis/avm/keychain.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L93)*
 
 Returns the address as a [Buffer](https://github.com/feross/buffer).
 
@@ -163,7 +163,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[getAddressString](_utils_types_.keypair.md#getaddressstring)*
 
-*Defined in [apis/avm/keychain.ts:102](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L102)*
+*Defined in [apis/avm/keychain.ts:102](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L102)*
 
 Returns the address's string representation.
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:246](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L246)*
+*Defined in [utils/types.ts:246](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L246)*
 
 Returns the chainID associated with this key.
 
@@ -195,7 +195,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:200](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L200)*
+*Defined in [utils/types.ts:200](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L200)*
 
 Returns a reference to the private key.
 
@@ -211,7 +211,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[getPrivateKeyString](_utils_types_.keypair.md#getprivatekeystring)*
 
-*Defined in [apis/avm/keychain.ts:136](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L136)*
+*Defined in [apis/avm/keychain.ts:136](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L136)*
 
 Returns a string representation of the private key.
 
@@ -227,7 +227,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:209](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L209)*
+*Defined in [utils/types.ts:209](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L209)*
 
 Returns a reference to the public key.
 
@@ -243,7 +243,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[getPublicKeyString](_utils_types_.keypair.md#getpublickeystring)*
 
-*Defined in [apis/avm/keychain.ts:145](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L145)*
+*Defined in [apis/avm/keychain.ts:145](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L145)*
 
 Returns the public key.
 
@@ -259,7 +259,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[importKey](_utils_types_.keypair.md#importkey)*
 
-*Defined in [apis/avm/keychain.ts:80](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L80)*
+*Defined in [apis/avm/keychain.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L80)*
 
 Imports a private key and generates the appropriate public key.
 
@@ -281,7 +281,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[recover](_utils_types_.keypair.md#recover)*
 
-*Defined in [apis/avm/keychain.ts:187](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L187)*
+*Defined in [apis/avm/keychain.ts:187](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L187)*
 
 Recovers the public key of a message signer from a message and its associated signature.
 
@@ -304,7 +304,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:255](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L255)*
+*Defined in [utils/types.ts:255](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L255)*
 
 Sets the the chainID associated with this key.
 
@@ -324,7 +324,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[sign](_utils_types_.keypair.md#sign)*
 
-*Defined in [apis/avm/keychain.ts:156](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L156)*
+*Defined in [apis/avm/keychain.ts:156](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L156)*
 
 Takes a message, signs it, and returns the signature.
 
@@ -346,7 +346,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[verify](_utils_types_.keypair.md#verify)*
 
-*Defined in [apis/avm/keychain.ts:174](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/keychain.ts#L174)*
+*Defined in [apis/avm/keychain.ts:174](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L174)*
 
 Verifies that the private key associated with the provided public key produces the signature associated with the given message.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_keychain_.avmkeypair.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_keychain_.avmkeypair.md
@@ -48,7 +48,7 @@ Class for representing a private and public keypair in the AVM.
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[constructor](_utils_types_.keypair.md#constructor)*
 
-*Defined in [apis/avm/keychain.ts:191](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L191)*
+*Defined in [apis/avm/keychain.ts:191](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L191)*
 
 Class for representing a private and public keypair in Slopes.
 
@@ -69,7 +69,7 @@ Name | Type | Default |
 
 *Inherited from [KeyPair](_utils_types_.keypair.md).[chainid](_utils_types_.keypair.md#protected-chainid)*
 
-*Defined in [utils/types.ts:148](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L148)*
+*Defined in [utils/types.ts:148](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L148)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **keypair**: *elliptic.ec.KeyPair*
 
-*Defined in [apis/avm/keychain.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L43)*
+*Defined in [apis/avm/keychain.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L43)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md).[privk](_utils_types_.keypair.md#protected-privk)*
 
-*Defined in [utils/types.ts:147](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L147)*
+*Defined in [utils/types.ts:147](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L147)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md).[pubk](_utils_types_.keypair.md#protected-pubk)*
 
-*Defined in [utils/types.ts:146](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L146)*
+*Defined in [utils/types.ts:146](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L146)*
 
 ## Methods
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **addressFromPublicKey**(`pubk`: Buffer): *Buffer*
 
-*Defined in [apis/avm/keychain.ts:114](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L114)*
+*Defined in [apis/avm/keychain.ts:114](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L114)*
 
 Returns an address given a public key.
 
@@ -127,7 +127,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[generateKey](_utils_types_.keypair.md#generatekey)*
 
-*Defined in [apis/avm/keychain.ts:65](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L65)*
+*Defined in [apis/avm/keychain.ts:65](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L65)*
 
 Generates a new keypair.
 
@@ -147,7 +147,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[getAddress](_utils_types_.keypair.md#getaddress)*
 
-*Defined in [apis/avm/keychain.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L93)*
+*Defined in [apis/avm/keychain.ts:93](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L93)*
 
 Returns the address as a [Buffer](https://github.com/feross/buffer).
 
@@ -163,7 +163,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[getAddressString](_utils_types_.keypair.md#getaddressstring)*
 
-*Defined in [apis/avm/keychain.ts:102](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L102)*
+*Defined in [apis/avm/keychain.ts:102](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L102)*
 
 Returns the address's string representation.
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:246](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L246)*
+*Defined in [utils/types.ts:246](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L246)*
 
 Returns the chainID associated with this key.
 
@@ -195,7 +195,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:200](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L200)*
+*Defined in [utils/types.ts:200](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L200)*
 
 Returns a reference to the private key.
 
@@ -211,7 +211,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[getPrivateKeyString](_utils_types_.keypair.md#getprivatekeystring)*
 
-*Defined in [apis/avm/keychain.ts:136](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L136)*
+*Defined in [apis/avm/keychain.ts:136](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L136)*
 
 Returns a string representation of the private key.
 
@@ -227,7 +227,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:209](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L209)*
+*Defined in [utils/types.ts:209](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L209)*
 
 Returns a reference to the public key.
 
@@ -243,7 +243,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[getPublicKeyString](_utils_types_.keypair.md#getpublickeystring)*
 
-*Defined in [apis/avm/keychain.ts:145](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L145)*
+*Defined in [apis/avm/keychain.ts:145](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L145)*
 
 Returns the public key.
 
@@ -259,7 +259,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[importKey](_utils_types_.keypair.md#importkey)*
 
-*Defined in [apis/avm/keychain.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L80)*
+*Defined in [apis/avm/keychain.ts:80](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L80)*
 
 Imports a private key and generates the appropriate public key.
 
@@ -281,7 +281,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[recover](_utils_types_.keypair.md#recover)*
 
-*Defined in [apis/avm/keychain.ts:187](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L187)*
+*Defined in [apis/avm/keychain.ts:187](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L187)*
 
 Recovers the public key of a message signer from a message and its associated signature.
 
@@ -304,7 +304,7 @@ ___
 
 *Inherited from [KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:255](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L255)*
+*Defined in [utils/types.ts:255](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L255)*
 
 Sets the the chainID associated with this key.
 
@@ -324,7 +324,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[sign](_utils_types_.keypair.md#sign)*
 
-*Defined in [apis/avm/keychain.ts:156](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L156)*
+*Defined in [apis/avm/keychain.ts:156](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L156)*
 
 Takes a message, signs it, and returns the signature.
 
@@ -346,7 +346,7 @@ ___
 
 *Overrides [KeyPair](_utils_types_.keypair.md).[verify](_utils_types_.keypair.md#verify)*
 
-*Defined in [apis/avm/keychain.ts:174](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/keychain.ts#L174)*
+*Defined in [apis/avm/keychain.ts:174](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/keychain.ts#L174)*
 
 Verifies that the private key associated with the provided public key produces the signature associated with the given message.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.nfttransferoperation.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.nfttransferoperation.md
@@ -42,7 +42,7 @@ A [Operation](_apis_avm_ops_.operation.md) class which specifies a NFT Transfer 
 
 *Overrides [Operation](_apis_avm_ops_.operation.md).[constructor](_apis_avm_ops_.operation.md#constructor)*
 
-*Defined in [apis/avm/ops.ts:242](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L242)*
+*Defined in [apis/avm/ops.ts:242](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L242)*
 
 An [Operation](_apis_avm_ops_.operation.md) class which contains an NFT on an assetID.
 
@@ -60,7 +60,7 @@ Name | Type | Default | Description |
 
 • **output**: *[NFTTransferOutput](_apis_avm_outputs_.nfttransferoutput.md)*
 
-*Defined in [apis/avm/ops.ts:204](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L204)*
+*Defined in [apis/avm/ops.ts:204](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L204)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md).[sigCount](_apis_avm_ops_.operation.md#protected-sigcount)*
 
-*Defined in [apis/avm/ops.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L31)*
+*Defined in [apis/avm/ops.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L31)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md).[sigIdxs](_apis_avm_ops_.operation.md#protected-sigidxs)*
 
-*Defined in [apis/avm/ops.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L32)*
+*Defined in [apis/avm/ops.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L32)*
 
 ## Methods
 
@@ -90,7 +90,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L53)*
+*Defined in [apis/avm/ops.ts:53](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Operation](_apis_avm_ops_.operation.md).
 
@@ -111,7 +111,7 @@ ___
 
 *Overrides [Operation](_apis_avm_ops_.operation.md).[fromBuffer](_apis_avm_ops_.operation.md#frombuffer)*
 
-*Defined in [apis/avm/ops.ts:220](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L220)*
+*Defined in [apis/avm/ops.ts:220](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L220)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [NFTTransferOperation](_apis_avm_ops_.nfttransferoperation.md) and returns the size of the output.
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L43)*
+*Defined in [apis/avm/ops.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L43)*
 
 **Returns:** *number*
 
@@ -144,7 +144,7 @@ ___
 
 *Overrides [Operation](_apis_avm_ops_.operation.md).[getOperationID](_apis_avm_ops_.operation.md#abstract-getoperationid)*
 
-*Defined in [apis/avm/ops.ts:209](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L209)*
+*Defined in [apis/avm/ops.ts:209](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L209)*
 
 Returns the operation ID.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **getOutput**(): *[NFTTransferOutput](_apis_avm_outputs_.nfttransferoutput.md)*
 
-*Defined in [apis/avm/ops.ts:213](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L213)*
+*Defined in [apis/avm/ops.ts:213](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L213)*
 
 **Returns:** *[NFTTransferOutput](_apis_avm_outputs_.nfttransferoutput.md)*
 
@@ -168,7 +168,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L39)*
+*Defined in [apis/avm/ops.ts:39](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Operation](_apis_avm_ops_.operation.md)
 
@@ -182,7 +182,7 @@ ___
 
 *Overrides [Operation](_apis_avm_ops_.operation.md).[toBuffer](_apis_avm_ops_.operation.md#tobuffer)*
 
-*Defined in [apis/avm/ops.ts:229](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L229)*
+*Defined in [apis/avm/ops.ts:229](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L229)*
 
 Returns the buffer representing the [NFTTransferOperation](_apis_avm_ops_.nfttransferoperation.md) instance.
 
@@ -194,7 +194,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/ops.ts:240](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L240)*
+*Defined in [apis/avm/ops.ts:240](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L240)*
 
 Returns a base-58 string representing the [NFTTransferOperation](_apis_avm_ops_.nfttransferoperation.md).
 
@@ -208,7 +208,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:90](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L90)*
+*Defined in [apis/avm/ops.ts:90](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L90)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.nfttransferoperation.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.nfttransferoperation.md
@@ -42,7 +42,7 @@ A [Operation](_apis_avm_ops_.operation.md) class which specifies a NFT Transfer 
 
 *Overrides [Operation](_apis_avm_ops_.operation.md).[constructor](_apis_avm_ops_.operation.md#constructor)*
 
-*Defined in [apis/avm/ops.ts:242](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L242)*
+*Defined in [apis/avm/ops.ts:242](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L242)*
 
 An [Operation](_apis_avm_ops_.operation.md) class which contains an NFT on an assetID.
 
@@ -60,7 +60,7 @@ Name | Type | Default | Description |
 
 • **output**: *[NFTTransferOutput](_apis_avm_outputs_.nfttransferoutput.md)*
 
-*Defined in [apis/avm/ops.ts:204](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L204)*
+*Defined in [apis/avm/ops.ts:204](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L204)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md).[sigCount](_apis_avm_ops_.operation.md#protected-sigcount)*
 
-*Defined in [apis/avm/ops.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L31)*
+*Defined in [apis/avm/ops.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L31)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md).[sigIdxs](_apis_avm_ops_.operation.md#protected-sigidxs)*
 
-*Defined in [apis/avm/ops.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L32)*
+*Defined in [apis/avm/ops.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L32)*
 
 ## Methods
 
@@ -90,7 +90,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:53](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L53)*
+*Defined in [apis/avm/ops.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Operation](_apis_avm_ops_.operation.md).
 
@@ -111,7 +111,7 @@ ___
 
 *Overrides [Operation](_apis_avm_ops_.operation.md).[fromBuffer](_apis_avm_ops_.operation.md#frombuffer)*
 
-*Defined in [apis/avm/ops.ts:220](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L220)*
+*Defined in [apis/avm/ops.ts:220](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L220)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [NFTTransferOperation](_apis_avm_ops_.nfttransferoperation.md) and returns the size of the output.
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L43)*
+*Defined in [apis/avm/ops.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L43)*
 
 **Returns:** *number*
 
@@ -144,7 +144,7 @@ ___
 
 *Overrides [Operation](_apis_avm_ops_.operation.md).[getOperationID](_apis_avm_ops_.operation.md#abstract-getoperationid)*
 
-*Defined in [apis/avm/ops.ts:209](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L209)*
+*Defined in [apis/avm/ops.ts:209](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L209)*
 
 Returns the operation ID.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **getOutput**(): *[NFTTransferOutput](_apis_avm_outputs_.nfttransferoutput.md)*
 
-*Defined in [apis/avm/ops.ts:213](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L213)*
+*Defined in [apis/avm/ops.ts:213](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L213)*
 
 **Returns:** *[NFTTransferOutput](_apis_avm_outputs_.nfttransferoutput.md)*
 
@@ -168,7 +168,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:39](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L39)*
+*Defined in [apis/avm/ops.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Operation](_apis_avm_ops_.operation.md)
 
@@ -182,7 +182,7 @@ ___
 
 *Overrides [Operation](_apis_avm_ops_.operation.md).[toBuffer](_apis_avm_ops_.operation.md#tobuffer)*
 
-*Defined in [apis/avm/ops.ts:229](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L229)*
+*Defined in [apis/avm/ops.ts:229](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L229)*
 
 Returns the buffer representing the [NFTTransferOperation](_apis_avm_ops_.nfttransferoperation.md) instance.
 
@@ -194,7 +194,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/ops.ts:240](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L240)*
+*Defined in [apis/avm/ops.ts:240](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L240)*
 
 Returns a base-58 string representing the [NFTTransferOperation](_apis_avm_ops_.nfttransferoperation.md).
 
@@ -208,7 +208,7 @@ ___
 
 *Inherited from [Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:90](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L90)*
+*Defined in [apis/avm/ops.ts:90](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L90)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.operation.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.operation.md
@@ -37,7 +37,7 @@ A class representing an operation. All operation types must extend on this class
 
 \+ **new Operation**(): *[Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:104](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L104)*
+*Defined in [apis/avm/ops.ts:104](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L104)*
 
 **Returns:** *[Operation](_apis_avm_ops_.operation.md)*
 
@@ -47,7 +47,7 @@ A class representing an operation. All operation types must extend on this class
 
 • **sigCount**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/ops.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L31)*
+*Defined in [apis/avm/ops.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L31)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **sigIdxs**: *Array‹[SigIdx](_apis_avm_types_.sigidx.md)›* =  []
 
-*Defined in [apis/avm/ops.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L32)*
+*Defined in [apis/avm/ops.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L32)*
 
 ## Methods
 
@@ -63,7 +63,7 @@ ___
 
 ▸ **addSignatureIdx**(`addressIdx`: number, `address`: Buffer): *void*
 
-*Defined in [apis/avm/ops.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L53)*
+*Defined in [apis/avm/ops.ts:53](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Operation](_apis_avm_ops_.operation.md).
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/ops.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L63)*
+*Defined in [apis/avm/ops.ts:63](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L63)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **getCredentialID**(): *number*
 
-*Defined in [apis/avm/ops.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L43)*
+*Defined in [apis/avm/ops.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L43)*
 
 **Returns:** *number*
 
@@ -109,7 +109,7 @@ ___
 
 ▸ **getOperationID**(): *number*
 
-*Defined in [apis/avm/ops.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L34)*
+*Defined in [apis/avm/ops.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L34)*
 
 **Returns:** *number*
 
@@ -119,7 +119,7 @@ ___
 
 ▸ **getSigIdxs**(): *Array‹[SigIdx](_apis_avm_types_.sigidx.md)›*
 
-*Defined in [apis/avm/ops.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L39)*
+*Defined in [apis/avm/ops.ts:39](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Operation](_apis_avm_ops_.operation.md)
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/ops.ts:78](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L78)*
+*Defined in [apis/avm/ops.ts:78](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L78)*
 
 **Returns:** *Buffer*
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/ops.ts:90](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L90)*
+*Defined in [apis/avm/ops.ts:90](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L90)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.operation.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.operation.md
@@ -37,7 +37,7 @@ A class representing an operation. All operation types must extend on this class
 
 \+ **new Operation**(): *[Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:104](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L104)*
+*Defined in [apis/avm/ops.ts:104](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L104)*
 
 **Returns:** *[Operation](_apis_avm_ops_.operation.md)*
 
@@ -47,7 +47,7 @@ A class representing an operation. All operation types must extend on this class
 
 • **sigCount**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/ops.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L31)*
+*Defined in [apis/avm/ops.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L31)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **sigIdxs**: *Array‹[SigIdx](_apis_avm_types_.sigidx.md)›* =  []
 
-*Defined in [apis/avm/ops.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L32)*
+*Defined in [apis/avm/ops.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L32)*
 
 ## Methods
 
@@ -63,7 +63,7 @@ ___
 
 ▸ **addSignatureIdx**(`addressIdx`: number, `address`: Buffer): *void*
 
-*Defined in [apis/avm/ops.ts:53](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L53)*
+*Defined in [apis/avm/ops.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L53)*
 
 Creates and adds a [SigIdx](_apis_avm_types_.sigidx.md) to the [Operation](_apis_avm_ops_.operation.md).
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/ops.ts:63](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L63)*
+*Defined in [apis/avm/ops.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L63)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **getCredentialID**(): *number*
 
-*Defined in [apis/avm/ops.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L43)*
+*Defined in [apis/avm/ops.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L43)*
 
 **Returns:** *number*
 
@@ -109,7 +109,7 @@ ___
 
 ▸ **getOperationID**(): *number*
 
-*Defined in [apis/avm/ops.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L34)*
+*Defined in [apis/avm/ops.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L34)*
 
 **Returns:** *number*
 
@@ -119,7 +119,7 @@ ___
 
 ▸ **getSigIdxs**(): *Array‹[SigIdx](_apis_avm_types_.sigidx.md)›*
 
-*Defined in [apis/avm/ops.ts:39](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L39)*
+*Defined in [apis/avm/ops.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L39)*
 
 Returns the array of [SigIdx](_apis_avm_types_.sigidx.md) for this [Operation](_apis_avm_ops_.operation.md)
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/ops.ts:78](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L78)*
+*Defined in [apis/avm/ops.ts:78](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L78)*
 
 **Returns:** *Buffer*
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/ops.ts:90](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L90)*
+*Defined in [apis/avm/ops.ts:90](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L90)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.transferableoperation.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.transferableoperation.md
@@ -34,7 +34,7 @@ A class which contains an [Operation](_apis_avm_ops_.operation.md) for transfers
 
 \+ **new TransferableOperation**(`assetid`: Buffer, `utxoids`: Array‹[UTXOID](_apis_avm_types_.utxoid.md) | string | Buffer›, `operation`: [Operation](_apis_avm_ops_.operation.md)): *[TransferableOperation](_apis_avm_ops_.transferableoperation.md)*
 
-*Defined in [apis/avm/ops.ts:175](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L175)*
+*Defined in [apis/avm/ops.ts:175](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L175)*
 
 **Parameters:**
 
@@ -52,7 +52,7 @@ Name | Type | Default |
 
 • **assetid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/ops.ts:115](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L115)*
+*Defined in [apis/avm/ops.ts:115](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L115)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • **operation**: *[Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:117](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L117)*
+*Defined in [apis/avm/ops.ts:117](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L117)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **utxoIDs**: *Array‹[UTXOID](_apis_avm_types_.utxoid.md)›* =  []
 
-*Defined in [apis/avm/ops.ts:116](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L116)*
+*Defined in [apis/avm/ops.ts:116](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L116)*
 
 ## Methods
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/ops.ts:119](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L119)*
+*Defined in [apis/avm/ops.ts:119](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L119)*
 
 **Parameters:**
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **getAssetID**(): *Buffer*
 
-*Defined in [apis/avm/ops.ts:159](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L159)*
+*Defined in [apis/avm/ops.ts:159](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L159)*
 
 Returns the assetID as a [Buffer](https://github.com/feross/buffer).
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **getOperation**(): *[Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:173](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L173)*
+*Defined in [apis/avm/ops.ts:173](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L173)*
 
 Returns the operation
 
@@ -117,7 +117,7 @@ ___
 
 ▸ **getUTXOIDs**(): *Array‹[UTXOID](_apis_avm_types_.utxoid.md)›*
 
-*Defined in [apis/avm/ops.ts:166](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L166)*
+*Defined in [apis/avm/ops.ts:166](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L166)*
 
 Returns an array of UTXOIDs in this operation.
 
@@ -129,6 +129,6 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/ops.ts:136](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L136)*
+*Defined in [apis/avm/ops.ts:136](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L136)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.transferableoperation.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_ops_.transferableoperation.md
@@ -34,7 +34,7 @@ A class which contains an [Operation](_apis_avm_ops_.operation.md) for transfers
 
 \+ **new TransferableOperation**(`assetid`: Buffer, `utxoids`: Array‹[UTXOID](_apis_avm_types_.utxoid.md) | string | Buffer›, `operation`: [Operation](_apis_avm_ops_.operation.md)): *[TransferableOperation](_apis_avm_ops_.transferableoperation.md)*
 
-*Defined in [apis/avm/ops.ts:175](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L175)*
+*Defined in [apis/avm/ops.ts:175](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L175)*
 
 **Parameters:**
 
@@ -52,7 +52,7 @@ Name | Type | Default |
 
 • **assetid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/ops.ts:115](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L115)*
+*Defined in [apis/avm/ops.ts:115](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L115)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • **operation**: *[Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:117](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L117)*
+*Defined in [apis/avm/ops.ts:117](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L117)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **utxoIDs**: *Array‹[UTXOID](_apis_avm_types_.utxoid.md)›* =  []
 
-*Defined in [apis/avm/ops.ts:116](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L116)*
+*Defined in [apis/avm/ops.ts:116](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L116)*
 
 ## Methods
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/ops.ts:119](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L119)*
+*Defined in [apis/avm/ops.ts:119](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L119)*
 
 **Parameters:**
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **getAssetID**(): *Buffer*
 
-*Defined in [apis/avm/ops.ts:159](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L159)*
+*Defined in [apis/avm/ops.ts:159](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L159)*
 
 Returns the assetID as a [Buffer](https://github.com/feross/buffer).
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **getOperation**(): *[Operation](_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:173](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L173)*
+*Defined in [apis/avm/ops.ts:173](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L173)*
 
 Returns the operation
 
@@ -117,7 +117,7 @@ ___
 
 ▸ **getUTXOIDs**(): *Array‹[UTXOID](_apis_avm_types_.utxoid.md)›*
 
-*Defined in [apis/avm/ops.ts:166](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L166)*
+*Defined in [apis/avm/ops.ts:166](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L166)*
 
 Returns an array of UTXOIDs in this operation.
 
@@ -129,6 +129,6 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/ops.ts:136](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L136)*
+*Defined in [apis/avm/ops.ts:136](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L136)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.amountoutput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.amountoutput.md
@@ -52,7 +52,7 @@ An [Output](_apis_avm_outputs_.output.md) class which specifies a token amount .
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[constructor](_apis_avm_outputs_.output.md#constructor)*
 
-*Defined in [apis/avm/outputs.ts:326](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L326)*
+*Defined in [apis/avm/outputs.ts:326](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L326)*
 
 An [AmountOutput](_apis_avm_outputs_.amountoutput.md) class which issues a payment on an assetID.
 
@@ -75,7 +75,7 @@ Name | Type | Default | Description |
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[addresses](_apis_avm_outputs_.output.md#protected-addresses)*
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 • **amount**: *Buffer* =  Buffer.alloc(8)
 
-*Defined in [apis/avm/outputs.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L297)*
+*Defined in [apis/avm/outputs.ts:297](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L297)*
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 • **amountValue**: *BN* =  new BN(0)
 
-*Defined in [apis/avm/outputs.ts:298](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L298)*
+*Defined in [apis/avm/outputs.ts:298](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L298)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[locktime](_apis_avm_outputs_.output.md#protected-locktime)*
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[numaddrs](_apis_avm_outputs_.output.md#protected-numaddrs)*
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[threshold](_apis_avm_outputs_.output.md#protected-threshold)*
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -131,7 +131,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[fromBuffer](_apis_avm_outputs_.output.md#frombuffer)*
 
-*Defined in [apis/avm/outputs.ts:310](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L310)*
+*Defined in [apis/avm/outputs.ts:310](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L310)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [AmountOutput](_apis_avm_outputs_.amountoutput.md) and returns the size of the output.
 
@@ -152,7 +152,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -174,7 +174,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -208,7 +208,7 @@ ___
 
 ▸ **getAmount**(): *BN*
 
-*Defined in [apis/avm/outputs.ts:303](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L303)*
+*Defined in [apis/avm/outputs.ts:303](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L303)*
 
 Returns the amount as a [BN](https://github.com/indutny/bn.js/).
 
@@ -222,7 +222,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -236,7 +236,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[getOutputID](_apis_avm_outputs_.output.md#abstract-getoutputid)*
 
-*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L38)*
+*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L38)*
 
 Returns the outputID for the output which tells parsers what type it is
 
@@ -250,7 +250,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -271,7 +271,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -285,7 +285,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[makeTransferable](_apis_avm_outputs_.output.md#maketransferable)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -303,7 +303,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -324,7 +324,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[toBuffer](_apis_avm_outputs_.output.md#tobuffer)*
 
-*Defined in [apis/avm/outputs.ts:320](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L320)*
+*Defined in [apis/avm/outputs.ts:320](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L320)*
 
 Returns the buffer representing the [AmountInput](_apis_avm_inputs_.amountinput.md) instance.
 
@@ -338,7 +338,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[toString](_apis_avm_outputs_.output.md#tostring)*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -352,7 +352,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.amountoutput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.amountoutput.md
@@ -52,7 +52,7 @@ An [Output](_apis_avm_outputs_.output.md) class which specifies a token amount .
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[constructor](_apis_avm_outputs_.output.md#constructor)*
 
-*Defined in [apis/avm/outputs.ts:326](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L326)*
+*Defined in [apis/avm/outputs.ts:326](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L326)*
 
 An [AmountOutput](_apis_avm_outputs_.amountoutput.md) class which issues a payment on an assetID.
 
@@ -75,7 +75,7 @@ Name | Type | Default | Description |
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[addresses](_apis_avm_outputs_.output.md#protected-addresses)*
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 • **amount**: *Buffer* =  Buffer.alloc(8)
 
-*Defined in [apis/avm/outputs.ts:297](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L297)*
+*Defined in [apis/avm/outputs.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L297)*
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 • **amountValue**: *BN* =  new BN(0)
 
-*Defined in [apis/avm/outputs.ts:298](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L298)*
+*Defined in [apis/avm/outputs.ts:298](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L298)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[locktime](_apis_avm_outputs_.output.md#protected-locktime)*
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[numaddrs](_apis_avm_outputs_.output.md#protected-numaddrs)*
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[threshold](_apis_avm_outputs_.output.md#protected-threshold)*
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -131,7 +131,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[fromBuffer](_apis_avm_outputs_.output.md#frombuffer)*
 
-*Defined in [apis/avm/outputs.ts:310](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L310)*
+*Defined in [apis/avm/outputs.ts:310](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L310)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [AmountOutput](_apis_avm_outputs_.amountoutput.md) and returns the size of the output.
 
@@ -152,7 +152,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -174,7 +174,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -208,7 +208,7 @@ ___
 
 ▸ **getAmount**(): *BN*
 
-*Defined in [apis/avm/outputs.ts:303](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L303)*
+*Defined in [apis/avm/outputs.ts:303](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L303)*
 
 Returns the amount as a [BN](https://github.com/indutny/bn.js/).
 
@@ -222,7 +222,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -236,7 +236,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[getOutputID](_apis_avm_outputs_.output.md#abstract-getoutputid)*
 
-*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L38)*
+*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L38)*
 
 Returns the outputID for the output which tells parsers what type it is
 
@@ -250,7 +250,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -271,7 +271,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -285,7 +285,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[makeTransferable](_apis_avm_outputs_.output.md#maketransferable)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -303,7 +303,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -324,7 +324,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[toBuffer](_apis_avm_outputs_.output.md#tobuffer)*
 
-*Defined in [apis/avm/outputs.ts:320](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L320)*
+*Defined in [apis/avm/outputs.ts:320](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L320)*
 
 Returns the buffer representing the [AmountInput](_apis_avm_inputs_.amountinput.md) instance.
 
@@ -338,7 +338,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[toString](_apis_avm_outputs_.output.md#tostring)*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -352,7 +352,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.nftoutbase.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.nftoutbase.md
@@ -54,7 +54,7 @@ An [Output](_apis_avm_outputs_.output.md) class which specifies an NFT.
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[constructor](_apis_avm_outputs_.output.md#constructor)*
 
-*Defined in [apis/avm/outputs.ts:403](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L403)*
+*Defined in [apis/avm/outputs.ts:403](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L403)*
 
 An [Output](_apis_avm_outputs_.output.md) class which contains an NFT on an assetID.
 
@@ -78,7 +78,7 @@ Name | Type | Default | Description |
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[addresses](_apis_avm_outputs_.output.md#protected-addresses)*
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • **groupID**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/outputs.ts:362](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L362)*
+*Defined in [apis/avm/outputs.ts:362](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L362)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[locktime](_apis_avm_outputs_.output.md#protected-locktime)*
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[numaddrs](_apis_avm_outputs_.output.md#protected-numaddrs)*
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 • **payload**: *Buffer*
 
-*Defined in [apis/avm/outputs.ts:364](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L364)*
+*Defined in [apis/avm/outputs.ts:364](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L364)*
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 • **sizePayload**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/outputs.ts:363](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L363)*
+*Defined in [apis/avm/outputs.ts:363](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L363)*
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[threshold](_apis_avm_outputs_.output.md#protected-threshold)*
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -142,7 +142,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[fromBuffer](_apis_avm_outputs_.output.md#frombuffer)*
 
-*Defined in [apis/avm/outputs.ts:383](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L383)*
+*Defined in [apis/avm/outputs.ts:383](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L383)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [NFTOutBase](_apis_avm_outputs_.nftoutbase.md) and returns the size of the output.
 
@@ -163,7 +163,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -185,7 +185,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -207,7 +207,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -219,7 +219,7 @@ ___
 
 ▸ **getGroupID**(): *number*
 
-*Defined in [apis/avm/outputs.ts:369](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L369)*
+*Defined in [apis/avm/outputs.ts:369](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L369)*
 
 Returns the groupID as a number.
 
@@ -233,7 +233,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -247,7 +247,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[getOutputID](_apis_avm_outputs_.output.md#abstract-getoutputid)*
 
-*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L38)*
+*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L38)*
 
 Returns the outputID for the output which tells parsers what type it is
 
@@ -259,7 +259,7 @@ ___
 
 ▸ **getPayload**(): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:376](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L376)*
+*Defined in [apis/avm/outputs.ts:376](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L376)*
 
 Returns the payload as a [Buffer](https://github.com/feross/buffer)
 
@@ -273,7 +273,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -308,7 +308,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[makeTransferable](_apis_avm_outputs_.output.md#maketransferable)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -326,7 +326,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -347,7 +347,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[toBuffer](_apis_avm_outputs_.output.md#tobuffer)*
 
-*Defined in [apis/avm/outputs.ts:397](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L397)*
+*Defined in [apis/avm/outputs.ts:397](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L397)*
 
 Returns the buffer representing the [NFTOutBase](_apis_avm_outputs_.nftoutbase.md) instance.
 
@@ -361,7 +361,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[toString](_apis_avm_outputs_.output.md#tostring)*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -375,7 +375,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.nftoutbase.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.nftoutbase.md
@@ -54,7 +54,7 @@ An [Output](_apis_avm_outputs_.output.md) class which specifies an NFT.
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[constructor](_apis_avm_outputs_.output.md#constructor)*
 
-*Defined in [apis/avm/outputs.ts:403](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L403)*
+*Defined in [apis/avm/outputs.ts:403](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L403)*
 
 An [Output](_apis_avm_outputs_.output.md) class which contains an NFT on an assetID.
 
@@ -78,7 +78,7 @@ Name | Type | Default | Description |
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[addresses](_apis_avm_outputs_.output.md#protected-addresses)*
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • **groupID**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/outputs.ts:362](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L362)*
+*Defined in [apis/avm/outputs.ts:362](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L362)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[locktime](_apis_avm_outputs_.output.md#protected-locktime)*
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[numaddrs](_apis_avm_outputs_.output.md#protected-numaddrs)*
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 • **payload**: *Buffer*
 
-*Defined in [apis/avm/outputs.ts:364](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L364)*
+*Defined in [apis/avm/outputs.ts:364](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L364)*
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 • **sizePayload**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/outputs.ts:363](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L363)*
+*Defined in [apis/avm/outputs.ts:363](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L363)*
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[threshold](_apis_avm_outputs_.output.md#protected-threshold)*
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -142,7 +142,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[fromBuffer](_apis_avm_outputs_.output.md#frombuffer)*
 
-*Defined in [apis/avm/outputs.ts:383](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L383)*
+*Defined in [apis/avm/outputs.ts:383](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L383)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [NFTOutBase](_apis_avm_outputs_.nftoutbase.md) and returns the size of the output.
 
@@ -163,7 +163,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -185,7 +185,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -207,7 +207,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -219,7 +219,7 @@ ___
 
 ▸ **getGroupID**(): *number*
 
-*Defined in [apis/avm/outputs.ts:369](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L369)*
+*Defined in [apis/avm/outputs.ts:369](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L369)*
 
 Returns the groupID as a number.
 
@@ -233,7 +233,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -247,7 +247,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[getOutputID](_apis_avm_outputs_.output.md#abstract-getoutputid)*
 
-*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L38)*
+*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L38)*
 
 Returns the outputID for the output which tells parsers what type it is
 
@@ -259,7 +259,7 @@ ___
 
 ▸ **getPayload**(): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:376](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L376)*
+*Defined in [apis/avm/outputs.ts:376](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L376)*
 
 Returns the payload as a [Buffer](https://github.com/feross/buffer)
 
@@ -273,7 +273,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -308,7 +308,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[makeTransferable](_apis_avm_outputs_.output.md#maketransferable)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -326,7 +326,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -347,7 +347,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[toBuffer](_apis_avm_outputs_.output.md#tobuffer)*
 
-*Defined in [apis/avm/outputs.ts:397](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L397)*
+*Defined in [apis/avm/outputs.ts:397](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L397)*
 
 Returns the buffer representing the [NFTOutBase](_apis_avm_outputs_.nftoutbase.md) instance.
 
@@ -361,7 +361,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[toString](_apis_avm_outputs_.output.md#tostring)*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -375,7 +375,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.nfttransferoutput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.nfttransferoutput.md
@@ -54,7 +54,7 @@ An [Output](_apis_avm_outputs_.output.md) class which specifies an Output that c
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[constructor](_apis_avm_outputs_.output.md#constructor)*
 
-*Defined in [apis/avm/outputs.ts:403](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L403)*
+*Defined in [apis/avm/outputs.ts:403](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L403)*
 
 An [Output](_apis_avm_outputs_.output.md) class which contains an NFT on an assetID.
 
@@ -78,7 +78,7 @@ Name | Type | Default | Description |
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[addresses](_apis_avm_outputs_.output.md#protected-addresses)*
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md).[groupID](_apis_avm_outputs_.nftoutbase.md#protected-groupid)*
 
-*Defined in [apis/avm/outputs.ts:362](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L362)*
+*Defined in [apis/avm/outputs.ts:362](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L362)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[locktime](_apis_avm_outputs_.output.md#protected-locktime)*
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[numaddrs](_apis_avm_outputs_.output.md#protected-numaddrs)*
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md).[payload](_apis_avm_outputs_.nftoutbase.md#protected-payload)*
 
-*Defined in [apis/avm/outputs.ts:364](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L364)*
+*Defined in [apis/avm/outputs.ts:364](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L364)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md).[sizePayload](_apis_avm_outputs_.nftoutbase.md#protected-sizepayload)*
 
-*Defined in [apis/avm/outputs.ts:363](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L363)*
+*Defined in [apis/avm/outputs.ts:363](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L363)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[threshold](_apis_avm_outputs_.output.md#protected-threshold)*
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -150,7 +150,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[fromBuffer](_apis_avm_outputs_.output.md#frombuffer)*
 
-*Defined in [apis/avm/outputs.ts:383](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L383)*
+*Defined in [apis/avm/outputs.ts:383](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L383)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [NFTOutBase](_apis_avm_outputs_.nftoutbase.md) and returns the size of the output.
 
@@ -171,7 +171,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -193,7 +193,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -215,7 +215,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -229,7 +229,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md)*
 
-*Defined in [apis/avm/outputs.ts:369](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L369)*
+*Defined in [apis/avm/outputs.ts:369](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L369)*
 
 Returns the groupID as a number.
 
@@ -243,7 +243,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -257,7 +257,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[getOutputID](_apis_avm_outputs_.output.md#abstract-getoutputid)*
 
-*Defined in [apis/avm/outputs.ts:431](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L431)*
+*Defined in [apis/avm/outputs.ts:431](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L431)*
 
 Returns the outputID for this output
 
@@ -271,7 +271,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md)*
 
-*Defined in [apis/avm/outputs.ts:376](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L376)*
+*Defined in [apis/avm/outputs.ts:376](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L376)*
 
 Returns the payload as a [Buffer](https://github.com/feross/buffer)
 
@@ -285,7 +285,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -306,7 +306,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -320,7 +320,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[makeTransferable](_apis_avm_outputs_.output.md#maketransferable)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -338,7 +338,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -361,7 +361,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[toBuffer](_apis_avm_outputs_.output.md#tobuffer)*
 
-*Defined in [apis/avm/outputs.ts:397](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L397)*
+*Defined in [apis/avm/outputs.ts:397](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L397)*
 
 Returns the buffer representing the [NFTOutBase](_apis_avm_outputs_.nftoutbase.md) instance.
 
@@ -375,7 +375,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[toString](_apis_avm_outputs_.output.md#tostring)*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -389,7 +389,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.nfttransferoutput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.nfttransferoutput.md
@@ -54,7 +54,7 @@ An [Output](_apis_avm_outputs_.output.md) class which specifies an Output that c
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[constructor](_apis_avm_outputs_.output.md#constructor)*
 
-*Defined in [apis/avm/outputs.ts:403](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L403)*
+*Defined in [apis/avm/outputs.ts:403](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L403)*
 
 An [Output](_apis_avm_outputs_.output.md) class which contains an NFT on an assetID.
 
@@ -78,7 +78,7 @@ Name | Type | Default | Description |
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[addresses](_apis_avm_outputs_.output.md#protected-addresses)*
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md).[groupID](_apis_avm_outputs_.nftoutbase.md#protected-groupid)*
 
-*Defined in [apis/avm/outputs.ts:362](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L362)*
+*Defined in [apis/avm/outputs.ts:362](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L362)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[locktime](_apis_avm_outputs_.output.md#protected-locktime)*
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[numaddrs](_apis_avm_outputs_.output.md#protected-numaddrs)*
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md).[payload](_apis_avm_outputs_.nftoutbase.md#protected-payload)*
 
-*Defined in [apis/avm/outputs.ts:364](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L364)*
+*Defined in [apis/avm/outputs.ts:364](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L364)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md).[sizePayload](_apis_avm_outputs_.nftoutbase.md#protected-sizepayload)*
 
-*Defined in [apis/avm/outputs.ts:363](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L363)*
+*Defined in [apis/avm/outputs.ts:363](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L363)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[threshold](_apis_avm_outputs_.output.md#protected-threshold)*
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -150,7 +150,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[fromBuffer](_apis_avm_outputs_.output.md#frombuffer)*
 
-*Defined in [apis/avm/outputs.ts:383](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L383)*
+*Defined in [apis/avm/outputs.ts:383](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L383)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [NFTOutBase](_apis_avm_outputs_.nftoutbase.md) and returns the size of the output.
 
@@ -171,7 +171,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -193,7 +193,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -215,7 +215,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -229,7 +229,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md)*
 
-*Defined in [apis/avm/outputs.ts:369](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L369)*
+*Defined in [apis/avm/outputs.ts:369](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L369)*
 
 Returns the groupID as a number.
 
@@ -243,7 +243,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -257,7 +257,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[getOutputID](_apis_avm_outputs_.output.md#abstract-getoutputid)*
 
-*Defined in [apis/avm/outputs.ts:431](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L431)*
+*Defined in [apis/avm/outputs.ts:431](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L431)*
 
 Returns the outputID for this output
 
@@ -271,7 +271,7 @@ ___
 
 *Inherited from [NFTOutBase](_apis_avm_outputs_.nftoutbase.md)*
 
-*Defined in [apis/avm/outputs.ts:376](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L376)*
+*Defined in [apis/avm/outputs.ts:376](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L376)*
 
 Returns the payload as a [Buffer](https://github.com/feross/buffer)
 
@@ -285,7 +285,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -306,7 +306,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -320,7 +320,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[makeTransferable](_apis_avm_outputs_.output.md#maketransferable)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -338,7 +338,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -361,7 +361,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[toBuffer](_apis_avm_outputs_.output.md#tobuffer)*
 
-*Defined in [apis/avm/outputs.ts:397](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L397)*
+*Defined in [apis/avm/outputs.ts:397](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L397)*
 
 Returns the buffer representing the [NFTOutBase](_apis_avm_outputs_.nftoutbase.md) instance.
 
@@ -375,7 +375,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[toString](_apis_avm_outputs_.output.md#tostring)*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -389,7 +389,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.output.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.output.md
@@ -45,7 +45,7 @@
 
 \+ **new Output**(`locktime`: BN, `threshold`: number, `addresses`: Array‹Buffer›): *[Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:210](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L210)*
+*Defined in [apis/avm/outputs.ts:210](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L210)*
 
 An [Output](_apis_avm_outputs_.output.md) class which contains locktimes, thresholds, and addresses.
 
@@ -65,7 +65,7 @@ Name | Type | Default | Description |
 
 • **addresses**: *Array‹[Address](_apis_avm_types_.address.md)›* =  []
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **locktime**: *Buffer* =  Buffer.alloc(8)
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **numaddrs**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **threshold**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/outputs.ts:147](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L147)*
+*Defined in [apis/avm/outputs.ts:147](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L147)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -116,7 +116,7 @@ ___
 
 ▸ **getAddress**(`idx`: number): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -136,7 +136,7 @@ ___
 
 ▸ **getAddressIdx**(`address`: Buffer): *number*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **getAddresses**(): *Array‹Buffer›*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **getLocktime**(): *BN*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -180,7 +180,7 @@ ___
 
 ▸ **getOutputID**(): *number*
 
-*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L38)*
+*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L38)*
 
 Returns the outputID for the output which tells parsers what type it is
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **getSpenders**(`addresses`: Array‹Buffer›, `asOf`: BN): *Array‹Buffer›*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -211,7 +211,7 @@ ___
 
 ▸ **getThreshold**(): *number*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -223,7 +223,7 @@ ___
 
 ▸ **makeTransferable**(`assetID`: Buffer): *[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -239,7 +239,7 @@ ___
 
 ▸ **meetsThreshold**(`addresses`: Array‹Buffer›, `asOf`: BN): *boolean*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -258,7 +258,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:168](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L168)*
+*Defined in [apis/avm/outputs.ts:168](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L168)*
 
 Returns the buffer representing the [Output](_apis_avm_outputs_.output.md) instance.
 
@@ -270,7 +270,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -282,7 +282,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.output.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.output.md
@@ -45,7 +45,7 @@
 
 \+ **new Output**(`locktime`: BN, `threshold`: number, `addresses`: Array‹Buffer›): *[Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:210](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L210)*
+*Defined in [apis/avm/outputs.ts:210](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L210)*
 
 An [Output](_apis_avm_outputs_.output.md) class which contains locktimes, thresholds, and addresses.
 
@@ -65,7 +65,7 @@ Name | Type | Default | Description |
 
 • **addresses**: *Array‹[Address](_apis_avm_types_.address.md)›* =  []
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **locktime**: *Buffer* =  Buffer.alloc(8)
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **numaddrs**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **threshold**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/outputs.ts:147](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L147)*
+*Defined in [apis/avm/outputs.ts:147](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L147)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -116,7 +116,7 @@ ___
 
 ▸ **getAddress**(`idx`: number): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -136,7 +136,7 @@ ___
 
 ▸ **getAddressIdx**(`address`: Buffer): *number*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **getAddresses**(): *Array‹Buffer›*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **getLocktime**(): *BN*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -180,7 +180,7 @@ ___
 
 ▸ **getOutputID**(): *number*
 
-*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L38)*
+*Defined in [apis/avm/outputs.ts:38](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L38)*
 
 Returns the outputID for the output which tells parsers what type it is
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **getSpenders**(`addresses`: Array‹Buffer›, `asOf`: BN): *Array‹Buffer›*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -211,7 +211,7 @@ ___
 
 ▸ **getThreshold**(): *number*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -223,7 +223,7 @@ ___
 
 ▸ **makeTransferable**(`assetID`: Buffer): *[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -239,7 +239,7 @@ ___
 
 ▸ **meetsThreshold**(`addresses`: Array‹Buffer›, `asOf`: BN): *boolean*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -258,7 +258,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:168](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L168)*
+*Defined in [apis/avm/outputs.ts:168](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L168)*
 
 Returns the buffer representing the [Output](_apis_avm_outputs_.output.md) instance.
 
@@ -270,7 +270,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -282,7 +282,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.secpoutput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.secpoutput.md
@@ -52,7 +52,7 @@ An [Output](_apis_avm_outputs_.output.md) class which specifies an Output that c
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[constructor](_apis_avm_outputs_.output.md#constructor)*
 
-*Defined in [apis/avm/outputs.ts:326](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L326)*
+*Defined in [apis/avm/outputs.ts:326](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L326)*
 
 An [AmountOutput](_apis_avm_outputs_.amountoutput.md) class which issues a payment on an assetID.
 
@@ -75,7 +75,7 @@ Name | Type | Default | Description |
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[addresses](_apis_avm_outputs_.output.md#protected-addresses)*
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 *Inherited from [AmountOutput](_apis_avm_outputs_.amountoutput.md).[amount](_apis_avm_outputs_.amountoutput.md#protected-amount)*
 
-*Defined in [apis/avm/outputs.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L297)*
+*Defined in [apis/avm/outputs.ts:297](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L297)*
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 *Inherited from [AmountOutput](_apis_avm_outputs_.amountoutput.md).[amountValue](_apis_avm_outputs_.amountoutput.md#protected-amountvalue)*
 
-*Defined in [apis/avm/outputs.ts:298](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L298)*
+*Defined in [apis/avm/outputs.ts:298](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L298)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[locktime](_apis_avm_outputs_.output.md#protected-locktime)*
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[numaddrs](_apis_avm_outputs_.output.md#protected-numaddrs)*
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[threshold](_apis_avm_outputs_.output.md#protected-threshold)*
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -137,7 +137,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[fromBuffer](_apis_avm_outputs_.output.md#frombuffer)*
 
-*Defined in [apis/avm/outputs.ts:310](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L310)*
+*Defined in [apis/avm/outputs.ts:310](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L310)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [AmountOutput](_apis_avm_outputs_.amountoutput.md) and returns the size of the output.
 
@@ -158,7 +158,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -180,7 +180,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -202,7 +202,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -216,7 +216,7 @@ ___
 
 *Inherited from [AmountOutput](_apis_avm_outputs_.amountoutput.md)*
 
-*Defined in [apis/avm/outputs.ts:303](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L303)*
+*Defined in [apis/avm/outputs.ts:303](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L303)*
 
 Returns the amount as a [BN](https://github.com/indutny/bn.js/).
 
@@ -230,7 +230,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -244,7 +244,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[getOutputID](_apis_avm_outputs_.output.md#abstract-getoutputid)*
 
-*Defined in [apis/avm/outputs.ts:352](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L352)*
+*Defined in [apis/avm/outputs.ts:352](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L352)*
 
 Returns the outputID for this output
 
@@ -258,7 +258,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -279,7 +279,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -293,7 +293,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[makeTransferable](_apis_avm_outputs_.output.md#maketransferable)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -311,7 +311,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -334,7 +334,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[toBuffer](_apis_avm_outputs_.output.md#tobuffer)*
 
-*Defined in [apis/avm/outputs.ts:320](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L320)*
+*Defined in [apis/avm/outputs.ts:320](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L320)*
 
 Returns the buffer representing the [AmountInput](_apis_avm_inputs_.amountinput.md) instance.
 
@@ -348,7 +348,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[toString](_apis_avm_outputs_.output.md#tostring)*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -362,7 +362,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.secpoutput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.secpoutput.md
@@ -52,7 +52,7 @@ An [Output](_apis_avm_outputs_.output.md) class which specifies an Output that c
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[constructor](_apis_avm_outputs_.output.md#constructor)*
 
-*Defined in [apis/avm/outputs.ts:326](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L326)*
+*Defined in [apis/avm/outputs.ts:326](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L326)*
 
 An [AmountOutput](_apis_avm_outputs_.amountoutput.md) class which issues a payment on an assetID.
 
@@ -75,7 +75,7 @@ Name | Type | Default | Description |
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[addresses](_apis_avm_outputs_.output.md#protected-addresses)*
 
-*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L33)*
+*Defined in [apis/avm/outputs.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L33)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 *Inherited from [AmountOutput](_apis_avm_outputs_.amountoutput.md).[amount](_apis_avm_outputs_.amountoutput.md#protected-amount)*
 
-*Defined in [apis/avm/outputs.ts:297](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L297)*
+*Defined in [apis/avm/outputs.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L297)*
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 *Inherited from [AmountOutput](_apis_avm_outputs_.amountoutput.md).[amountValue](_apis_avm_outputs_.amountoutput.md#protected-amountvalue)*
 
-*Defined in [apis/avm/outputs.ts:298](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L298)*
+*Defined in [apis/avm/outputs.ts:298](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L298)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[locktime](_apis_avm_outputs_.output.md#protected-locktime)*
 
-*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L30)*
+*Defined in [apis/avm/outputs.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L30)*
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[numaddrs](_apis_avm_outputs_.output.md#protected-numaddrs)*
 
-*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L32)*
+*Defined in [apis/avm/outputs.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L32)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[threshold](_apis_avm_outputs_.output.md#protected-threshold)*
 
-*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L31)*
+*Defined in [apis/avm/outputs.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L31)*
 
 ## Methods
 
@@ -137,7 +137,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[fromBuffer](_apis_avm_outputs_.output.md#frombuffer)*
 
-*Defined in [apis/avm/outputs.ts:310](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L310)*
+*Defined in [apis/avm/outputs.ts:310](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L310)*
 
 Popuates the instance from a [Buffer](https://github.com/feross/buffer) representing the [AmountOutput](_apis_avm_outputs_.amountoutput.md) and returns the size of the output.
 
@@ -158,7 +158,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L89)*
+*Defined in [apis/avm/outputs.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L89)*
 
 Returns the address from the index provided.
 
@@ -180,7 +180,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L72)*
+*Defined in [apis/avm/outputs.ts:72](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L72)*
 
 Returns the index of the address.
 
@@ -202,7 +202,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L57)*
+*Defined in [apis/avm/outputs.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L57)*
 
 Returns an array of [Buffer](https://github.com/feross/buffer)s for the addresses.
 
@@ -216,7 +216,7 @@ ___
 
 *Inherited from [AmountOutput](_apis_avm_outputs_.amountoutput.md)*
 
-*Defined in [apis/avm/outputs.ts:303](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L303)*
+*Defined in [apis/avm/outputs.ts:303](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L303)*
 
 Returns the amount as a [BN](https://github.com/indutny/bn.js/).
 
@@ -230,7 +230,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L50)*
+*Defined in [apis/avm/outputs.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L50)*
 
 Returns the a [BN](https://github.com/indutny/bn.js/) repersenting the UNIX Timestamp when the lock is made available.
 
@@ -244,7 +244,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[getOutputID](_apis_avm_outputs_.output.md#abstract-getoutputid)*
 
-*Defined in [apis/avm/outputs.ts:352](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L352)*
+*Defined in [apis/avm/outputs.ts:352](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L352)*
 
 Returns the outputID for this output
 
@@ -258,7 +258,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L118)*
+*Defined in [apis/avm/outputs.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L118)*
 
 Given an array of addresses and an optional timestamp, select an array of address [Buffer](https://github.com/feross/buffer)s of qualified spenders for the output.
 
@@ -279,7 +279,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L43)*
+*Defined in [apis/avm/outputs.ts:43](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L43)*
 
 Returns the threshold of signers required to spend this output.
 
@@ -293,7 +293,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[makeTransferable](_apis_avm_outputs_.output.md#maketransferable)*
 
-*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L192)*
+*Defined in [apis/avm/outputs.ts:192](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L192)*
 
 **Parameters:**
 
@@ -311,7 +311,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L99)*
+*Defined in [apis/avm/outputs.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L99)*
 
 Given an array of address [Buffer](https://github.com/feross/buffer)s and an optional timestamp, returns true if the addresses meet the threshold required to spend the output.
 
@@ -334,7 +334,7 @@ ___
 
 *Overrides [Output](_apis_avm_outputs_.output.md).[toBuffer](_apis_avm_outputs_.output.md#tobuffer)*
 
-*Defined in [apis/avm/outputs.ts:320](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L320)*
+*Defined in [apis/avm/outputs.ts:320](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L320)*
 
 Returns the buffer representing the [AmountInput](_apis_avm_inputs_.amountinput.md) instance.
 
@@ -348,7 +348,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md).[toString](_apis_avm_outputs_.output.md#tostring)*
 
-*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L184)*
+*Defined in [apis/avm/outputs.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L184)*
 
 Returns a base-58 string representing the [Output](_apis_avm_outputs_.output.md).
 
@@ -362,7 +362,7 @@ ___
 
 *Inherited from [Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L196)*
+*Defined in [apis/avm/outputs.ts:196](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L196)*
 
 **Returns:** *function*
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.transferableoutput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.transferableoutput.md
@@ -31,7 +31,7 @@
 
 \+ **new TransferableOutput**(`assetID`: Buffer, `output`: [Output](_apis_avm_outputs_.output.md)): *[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)*
 
-*Defined in [apis/avm/outputs.ts:277](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L277)*
+*Defined in [apis/avm/outputs.ts:277](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L277)*
 
 Class representing an [TransferableOutput](_apis_avm_outputs_.transferableoutput.md) for a transaction.
 
@@ -50,7 +50,7 @@ Name | Type | Default | Description |
 
 • **assetID**: *Buffer* =  Buffer.alloc(AVMConstants.ASSETIDLEN)
 
-*Defined in [apis/avm/outputs.ts:240](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L240)*
+*Defined in [apis/avm/outputs.ts:240](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L240)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • **output**: *[Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:241](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L241)*
+*Defined in [apis/avm/outputs.ts:241](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L241)*
 
 ## Methods
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/outputs.ts:262](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L262)*
+*Defined in [apis/avm/outputs.ts:262](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L262)*
 
 **Parameters:**
 
@@ -83,7 +83,7 @@ ___
 
 ▸ **getAssetID**(): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:254](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L254)*
+*Defined in [apis/avm/outputs.ts:254](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L254)*
 
 **Returns:** *Buffer*
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **getOutput**(): *[Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:258](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L258)*
+*Defined in [apis/avm/outputs.ts:258](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L258)*
 
 **Returns:** *[Output](_apis_avm_outputs_.output.md)*
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:271](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L271)*
+*Defined in [apis/avm/outputs.ts:271](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L271)*
 
 **Returns:** *Buffer*
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/outputs.ts:246](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L246)*
+*Defined in [apis/avm/outputs.ts:246](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L246)*
 
 Returns a function used to sort an array of [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.transferableoutput.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_outputs_.transferableoutput.md
@@ -31,7 +31,7 @@
 
 \+ **new TransferableOutput**(`assetID`: Buffer, `output`: [Output](_apis_avm_outputs_.output.md)): *[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)*
 
-*Defined in [apis/avm/outputs.ts:277](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L277)*
+*Defined in [apis/avm/outputs.ts:277](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L277)*
 
 Class representing an [TransferableOutput](_apis_avm_outputs_.transferableoutput.md) for a transaction.
 
@@ -50,7 +50,7 @@ Name | Type | Default | Description |
 
 • **assetID**: *Buffer* =  Buffer.alloc(AVMConstants.ASSETIDLEN)
 
-*Defined in [apis/avm/outputs.ts:240](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L240)*
+*Defined in [apis/avm/outputs.ts:240](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L240)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • **output**: *[Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:241](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L241)*
+*Defined in [apis/avm/outputs.ts:241](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L241)*
 
 ## Methods
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/outputs.ts:262](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L262)*
+*Defined in [apis/avm/outputs.ts:262](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L262)*
 
 **Parameters:**
 
@@ -83,7 +83,7 @@ ___
 
 ▸ **getAssetID**(): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:254](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L254)*
+*Defined in [apis/avm/outputs.ts:254](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L254)*
 
 **Returns:** *Buffer*
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **getOutput**(): *[Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:258](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L258)*
+*Defined in [apis/avm/outputs.ts:258](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L258)*
 
 **Returns:** *[Output](_apis_avm_outputs_.output.md)*
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/outputs.ts:271](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L271)*
+*Defined in [apis/avm/outputs.ts:271](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L271)*
 
 **Returns:** *Buffer*
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **comparator**(): *function*
 
-*Defined in [apis/avm/outputs.ts:246](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L246)*
+*Defined in [apis/avm/outputs.ts:246](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L246)*
 
 Returns a function used to sort an array of [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.basetx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.basetx.md
@@ -45,7 +45,7 @@ Class representing a base for all transactions.
 
 \+ **new BaseTx**(`networkid`: number, `blockchainid`: Buffer, `outs`: Array‹[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)›, `ins`: Array‹[TransferableInput](_apis_avm_inputs_.transferableinput.md)›): *[BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:179](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L179)*
+*Defined in [apis/avm/tx.ts:179](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L179)*
 
 Class representing a BaseTx which is the foundation for all transactions.
 
@@ -66,7 +66,7 @@ Name | Type | Default | Description |
 
 • **blockchainid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L46)*
+*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L46)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 • **ins**: *Array‹[TransferableInput](_apis_avm_inputs_.transferableinput.md)›*
 
-*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L50)*
+*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L50)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • **networkid**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L45)*
+*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L45)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 • **numins**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L49)*
+*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L49)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 • **numouts**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L47)*
+*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L47)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 • **outs**: *Array‹[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)›*
 
-*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L48)*
+*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L48)*
 
 ## Methods
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/tx.ts:96](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L96)*
+*Defined in [apis/avm/tx.ts:96](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L96)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [BaseTx](_apis_avm_tx_.basetx.md), parses it, populates the class, and returns the length of the BaseTx in bytes.
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **getBlockchainID**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L69)*
+*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L69)*
 
 Returns the Buffer representation of the BlockchainID
 
@@ -149,7 +149,7 @@ ___
 
 ▸ **getIns**(): *Array‹[TransferableInput](_apis_avm_inputs_.transferableinput.md)›*
 
-*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L76)*
+*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L76)*
 
 Returns the array of [TransferableInput](_apis_avm_inputs_.transferableinput.md)s
 
@@ -161,7 +161,7 @@ ___
 
 ▸ **getNetworkID**(): *number*
 
-*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L62)*
+*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L62)*
 
 Returns the NetworkID as a number
 
@@ -173,7 +173,7 @@ ___
 
 ▸ **getOuts**(): *Array‹[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)›*
 
-*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L83)*
+*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L83)*
 
 Returns the array of [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getTxType**(): *number*
 
-*Defined in [apis/avm/tx.ts:55](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L55)*
+*Defined in [apis/avm/tx.ts:55](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L55)*
 
 Returns the id of the [BaseTx](_apis_avm_tx_.basetx.md)
 
@@ -197,7 +197,7 @@ ___
 
 ▸ **sign**(`msg`: Buffer, `kc`: [AVMKeyChain](_apis_avm_keychain_.avmkeychain.md)): *Array‹[Credential](_apis_avm_credentials_.credential.md)›*
 
-*Defined in [apis/avm/tx.ts:164](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L164)*
+*Defined in [apis/avm/tx.ts:164](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L164)*
 
 Takes the bytes of an [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns an array of [Credential](_apis_avm_credentials_.credential.md)s
 
@@ -218,7 +218,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:126](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L126)*
+*Defined in [apis/avm/tx.ts:126](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L126)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [BaseTx](_apis_avm_tx_.basetx.md).
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L152)*
+*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L152)*
 
 Returns a base-58 representation of the [BaseTx](_apis_avm_tx_.basetx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.basetx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.basetx.md
@@ -45,7 +45,7 @@ Class representing a base for all transactions.
 
 \+ **new BaseTx**(`networkid`: number, `blockchainid`: Buffer, `outs`: Array‹[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)›, `ins`: Array‹[TransferableInput](_apis_avm_inputs_.transferableinput.md)›): *[BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:179](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L179)*
+*Defined in [apis/avm/tx.ts:179](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L179)*
 
 Class representing a BaseTx which is the foundation for all transactions.
 
@@ -66,7 +66,7 @@ Name | Type | Default | Description |
 
 • **blockchainid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L46)*
+*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L46)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 • **ins**: *Array‹[TransferableInput](_apis_avm_inputs_.transferableinput.md)›*
 
-*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L50)*
+*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L50)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • **networkid**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L45)*
+*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L45)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 • **numins**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L49)*
+*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L49)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 • **numouts**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L47)*
+*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L47)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 • **outs**: *Array‹[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)›*
 
-*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L48)*
+*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L48)*
 
 ## Methods
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/tx.ts:96](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L96)*
+*Defined in [apis/avm/tx.ts:96](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L96)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [BaseTx](_apis_avm_tx_.basetx.md), parses it, populates the class, and returns the length of the BaseTx in bytes.
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **getBlockchainID**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L69)*
+*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L69)*
 
 Returns the Buffer representation of the BlockchainID
 
@@ -149,7 +149,7 @@ ___
 
 ▸ **getIns**(): *Array‹[TransferableInput](_apis_avm_inputs_.transferableinput.md)›*
 
-*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L76)*
+*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L76)*
 
 Returns the array of [TransferableInput](_apis_avm_inputs_.transferableinput.md)s
 
@@ -161,7 +161,7 @@ ___
 
 ▸ **getNetworkID**(): *number*
 
-*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L62)*
+*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L62)*
 
 Returns the NetworkID as a number
 
@@ -173,7 +173,7 @@ ___
 
 ▸ **getOuts**(): *Array‹[TransferableOutput](_apis_avm_outputs_.transferableoutput.md)›*
 
-*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L83)*
+*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L83)*
 
 Returns the array of [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getTxType**(): *number*
 
-*Defined in [apis/avm/tx.ts:55](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L55)*
+*Defined in [apis/avm/tx.ts:55](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L55)*
 
 Returns the id of the [BaseTx](_apis_avm_tx_.basetx.md)
 
@@ -197,7 +197,7 @@ ___
 
 ▸ **sign**(`msg`: Buffer, `kc`: [AVMKeyChain](_apis_avm_keychain_.avmkeychain.md)): *Array‹[Credential](_apis_avm_credentials_.credential.md)›*
 
-*Defined in [apis/avm/tx.ts:164](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L164)*
+*Defined in [apis/avm/tx.ts:164](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L164)*
 
 Takes the bytes of an [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns an array of [Credential](_apis_avm_credentials_.credential.md)s
 
@@ -218,7 +218,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:126](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L126)*
+*Defined in [apis/avm/tx.ts:126](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L126)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [BaseTx](_apis_avm_tx_.basetx.md).
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L152)*
+*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L152)*
 
 Returns a base-58 representation of the [BaseTx](_apis_avm_tx_.basetx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.createassettx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.createassettx.md
@@ -52,7 +52,7 @@
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[constructor](_apis_avm_tx_.basetx.md#constructor)*
 
-*Defined in [apis/avm/tx.ts:305](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L305)*
+*Defined in [apis/avm/tx.ts:305](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L305)*
 
 Class representing an unsigned Create Asset transaction.
 
@@ -79,7 +79,7 @@ Name | Type | Default | Description |
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[blockchainid](_apis_avm_tx_.basetx.md#protected-blockchainid)*
 
-*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L46)*
+*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L46)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 • **denomination**: *Buffer* =  Buffer.alloc(1)
 
-*Defined in [apis/avm/tx.ts:204](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L204)*
+*Defined in [apis/avm/tx.ts:204](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L204)*
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 • **initialstate**: *[InitialStates](_apis_avm_types_.initialstates.md)* =  new InitialStates()
 
-*Defined in [apis/avm/tx.ts:205](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L205)*
+*Defined in [apis/avm/tx.ts:205](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L205)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[ins](_apis_avm_tx_.basetx.md#protected-ins)*
 
-*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L50)*
+*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L50)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **name**: *string* = ""
 
-*Defined in [apis/avm/tx.ts:202](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L202)*
+*Defined in [apis/avm/tx.ts:202](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L202)*
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[networkid](_apis_avm_tx_.basetx.md#protected-networkid)*
 
-*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L45)*
+*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L45)*
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[numins](_apis_avm_tx_.basetx.md#protected-numins)*
 
-*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L49)*
+*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L49)*
 
 ___
 
@@ -143,7 +143,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[numouts](_apis_avm_tx_.basetx.md#protected-numouts)*
 
-*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L47)*
+*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L47)*
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[outs](_apis_avm_tx_.basetx.md#protected-outs)*
 
-*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L48)*
+*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L48)*
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 • **symbol**: *string* = ""
 
-*Defined in [apis/avm/tx.ts:203](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L203)*
+*Defined in [apis/avm/tx.ts:203](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L203)*
 
 ## Methods
 
@@ -171,7 +171,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[fromBuffer](_apis_avm_tx_.basetx.md#frombuffer)*
 
-*Defined in [apis/avm/tx.ts:262](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L262)*
+*Defined in [apis/avm/tx.ts:262](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L262)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [CreateAssetTx](_apis_avm_tx_.createassettx.md), parses it, populates the class, and returns the length of the [CreateAssetTx](_apis_avm_tx_.createassettx.md) in bytes.
 
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L69)*
+*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L69)*
 
 Returns the Buffer representation of the BlockchainID
 
@@ -208,7 +208,7 @@ ___
 
 ▸ **getDenomination**(): *number*
 
-*Defined in [apis/avm/tx.ts:241](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L241)*
+*Defined in [apis/avm/tx.ts:241](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L241)*
 
 Returns the numeric representation of the denomination
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **getDenominationBuffer**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:249](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L249)*
+*Defined in [apis/avm/tx.ts:249](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L249)*
 
 Returns the [Buffer](https://github.com/feross/buffer) representation of the denomination
 
@@ -232,7 +232,7 @@ ___
 
 ▸ **getInitialStates**(): *[InitialStates](_apis_avm_types_.initialstates.md)*
 
-*Defined in [apis/avm/tx.ts:217](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L217)*
+*Defined in [apis/avm/tx.ts:217](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L217)*
 
 Returns the array of array of [Output](_apis_avm_outputs_.output.md)s for the initial state
 
@@ -246,7 +246,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L76)*
+*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L76)*
 
 Returns the array of [TransferableInput](_apis_avm_inputs_.transferableinput.md)s
 
@@ -258,7 +258,7 @@ ___
 
 ▸ **getName**(): *string*
 
-*Defined in [apis/avm/tx.ts:224](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L224)*
+*Defined in [apis/avm/tx.ts:224](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L224)*
 
 Returns the string representation of the name
 
@@ -272,7 +272,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L62)*
+*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L62)*
 
 Returns the NetworkID as a number
 
@@ -286,7 +286,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L83)*
+*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L83)*
 
 Returns the array of [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s
 
@@ -298,7 +298,7 @@ ___
 
 ▸ **getSymbol**(): *string*
 
-*Defined in [apis/avm/tx.ts:232](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L232)*
+*Defined in [apis/avm/tx.ts:232](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L232)*
 
 Returns the string representation of the symbol
 
@@ -312,7 +312,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[getTxType](_apis_avm_tx_.basetx.md#gettxtype)*
 
-*Defined in [apis/avm/tx.ts:210](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L210)*
+*Defined in [apis/avm/tx.ts:210](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L210)*
 
 Returns the id of the [CreateAssetTx](_apis_avm_tx_.createassettx.md)
 
@@ -326,7 +326,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[sign](_apis_avm_tx_.basetx.md#sign)*
 
-*Defined in [apis/avm/tx.ts:164](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L164)*
+*Defined in [apis/avm/tx.ts:164](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L164)*
 
 Takes the bytes of an [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns an array of [Credential](_apis_avm_credentials_.credential.md)s
 
@@ -349,7 +349,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[toBuffer](_apis_avm_tx_.basetx.md#tobuffer)*
 
-*Defined in [apis/avm/tx.ts:288](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L288)*
+*Defined in [apis/avm/tx.ts:288](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L288)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [CreateAssetTx](_apis_avm_tx_.createassettx.md).
 
@@ -363,7 +363,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[toString](_apis_avm_tx_.basetx.md#tostring)*
 
-*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L152)*
+*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L152)*
 
 Returns a base-58 representation of the [BaseTx](_apis_avm_tx_.basetx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.createassettx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.createassettx.md
@@ -52,7 +52,7 @@
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[constructor](_apis_avm_tx_.basetx.md#constructor)*
 
-*Defined in [apis/avm/tx.ts:305](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L305)*
+*Defined in [apis/avm/tx.ts:305](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L305)*
 
 Class representing an unsigned Create Asset transaction.
 
@@ -79,7 +79,7 @@ Name | Type | Default | Description |
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[blockchainid](_apis_avm_tx_.basetx.md#protected-blockchainid)*
 
-*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L46)*
+*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L46)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 • **denomination**: *Buffer* =  Buffer.alloc(1)
 
-*Defined in [apis/avm/tx.ts:204](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L204)*
+*Defined in [apis/avm/tx.ts:204](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L204)*
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 • **initialstate**: *[InitialStates](_apis_avm_types_.initialstates.md)* =  new InitialStates()
 
-*Defined in [apis/avm/tx.ts:205](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L205)*
+*Defined in [apis/avm/tx.ts:205](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L205)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[ins](_apis_avm_tx_.basetx.md#protected-ins)*
 
-*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L50)*
+*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L50)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **name**: *string* = ""
 
-*Defined in [apis/avm/tx.ts:202](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L202)*
+*Defined in [apis/avm/tx.ts:202](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L202)*
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[networkid](_apis_avm_tx_.basetx.md#protected-networkid)*
 
-*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L45)*
+*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L45)*
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[numins](_apis_avm_tx_.basetx.md#protected-numins)*
 
-*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L49)*
+*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L49)*
 
 ___
 
@@ -143,7 +143,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[numouts](_apis_avm_tx_.basetx.md#protected-numouts)*
 
-*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L47)*
+*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L47)*
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[outs](_apis_avm_tx_.basetx.md#protected-outs)*
 
-*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L48)*
+*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L48)*
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 • **symbol**: *string* = ""
 
-*Defined in [apis/avm/tx.ts:203](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L203)*
+*Defined in [apis/avm/tx.ts:203](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L203)*
 
 ## Methods
 
@@ -171,7 +171,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[fromBuffer](_apis_avm_tx_.basetx.md#frombuffer)*
 
-*Defined in [apis/avm/tx.ts:262](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L262)*
+*Defined in [apis/avm/tx.ts:262](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L262)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [CreateAssetTx](_apis_avm_tx_.createassettx.md), parses it, populates the class, and returns the length of the [CreateAssetTx](_apis_avm_tx_.createassettx.md) in bytes.
 
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L69)*
+*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L69)*
 
 Returns the Buffer representation of the BlockchainID
 
@@ -208,7 +208,7 @@ ___
 
 ▸ **getDenomination**(): *number*
 
-*Defined in [apis/avm/tx.ts:241](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L241)*
+*Defined in [apis/avm/tx.ts:241](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L241)*
 
 Returns the numeric representation of the denomination
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **getDenominationBuffer**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:249](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L249)*
+*Defined in [apis/avm/tx.ts:249](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L249)*
 
 Returns the [Buffer](https://github.com/feross/buffer) representation of the denomination
 
@@ -232,7 +232,7 @@ ___
 
 ▸ **getInitialStates**(): *[InitialStates](_apis_avm_types_.initialstates.md)*
 
-*Defined in [apis/avm/tx.ts:217](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L217)*
+*Defined in [apis/avm/tx.ts:217](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L217)*
 
 Returns the array of array of [Output](_apis_avm_outputs_.output.md)s for the initial state
 
@@ -246,7 +246,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L76)*
+*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L76)*
 
 Returns the array of [TransferableInput](_apis_avm_inputs_.transferableinput.md)s
 
@@ -258,7 +258,7 @@ ___
 
 ▸ **getName**(): *string*
 
-*Defined in [apis/avm/tx.ts:224](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L224)*
+*Defined in [apis/avm/tx.ts:224](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L224)*
 
 Returns the string representation of the name
 
@@ -272,7 +272,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L62)*
+*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L62)*
 
 Returns the NetworkID as a number
 
@@ -286,7 +286,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L83)*
+*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L83)*
 
 Returns the array of [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s
 
@@ -298,7 +298,7 @@ ___
 
 ▸ **getSymbol**(): *string*
 
-*Defined in [apis/avm/tx.ts:232](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L232)*
+*Defined in [apis/avm/tx.ts:232](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L232)*
 
 Returns the string representation of the symbol
 
@@ -312,7 +312,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[getTxType](_apis_avm_tx_.basetx.md#gettxtype)*
 
-*Defined in [apis/avm/tx.ts:210](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L210)*
+*Defined in [apis/avm/tx.ts:210](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L210)*
 
 Returns the id of the [CreateAssetTx](_apis_avm_tx_.createassettx.md)
 
@@ -326,7 +326,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[sign](_apis_avm_tx_.basetx.md#sign)*
 
-*Defined in [apis/avm/tx.ts:164](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L164)*
+*Defined in [apis/avm/tx.ts:164](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L164)*
 
 Takes the bytes of an [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns an array of [Credential](_apis_avm_credentials_.credential.md)s
 
@@ -349,7 +349,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[toBuffer](_apis_avm_tx_.basetx.md#tobuffer)*
 
-*Defined in [apis/avm/tx.ts:288](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L288)*
+*Defined in [apis/avm/tx.ts:288](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L288)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [CreateAssetTx](_apis_avm_tx_.createassettx.md).
 
@@ -363,7 +363,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[toString](_apis_avm_tx_.basetx.md#tostring)*
 
-*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L152)*
+*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L152)*
 
 Returns a base-58 representation of the [BaseTx](_apis_avm_tx_.basetx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.operationtx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.operationtx.md
@@ -48,7 +48,7 @@ Class representing an unsigned Operation transaction.
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[constructor](_apis_avm_tx_.basetx.md#constructor)*
 
-*Defined in [apis/avm/tx.ts:416](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L416)*
+*Defined in [apis/avm/tx.ts:416](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L416)*
 
 Class representing an unsigned Operation transaction.
 
@@ -72,7 +72,7 @@ Name | Type | Default | Description |
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[blockchainid](_apis_avm_tx_.basetx.md#protected-blockchainid)*
 
-*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L46)*
+*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L46)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[ins](_apis_avm_tx_.basetx.md#protected-ins)*
 
-*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L50)*
+*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L50)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[networkid](_apis_avm_tx_.basetx.md#protected-networkid)*
 
-*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L45)*
+*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L45)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 • **numOps**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/tx.ts:342](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L342)*
+*Defined in [apis/avm/tx.ts:342](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L342)*
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[numins](_apis_avm_tx_.basetx.md#protected-numins)*
 
-*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L49)*
+*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L49)*
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[numouts](_apis_avm_tx_.basetx.md#protected-numouts)*
 
-*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L47)*
+*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L47)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 • **ops**: *Array‹[TransferableOperation](_apis_avm_ops_.transferableoperation.md)›* =  []
 
-*Defined in [apis/avm/tx.ts:343](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L343)*
+*Defined in [apis/avm/tx.ts:343](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L343)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[outs](_apis_avm_tx_.basetx.md#protected-outs)*
 
-*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L48)*
+*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L48)*
 
 ## Methods
 
@@ -148,7 +148,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[fromBuffer](_apis_avm_tx_.basetx.md#frombuffer)*
 
-*Defined in [apis/avm/tx.ts:361](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L361)*
+*Defined in [apis/avm/tx.ts:361](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L361)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [OperationTx](_apis_avm_tx_.operationtx.md), parses it, populates the class, and returns the length of the [OperationTx](_apis_avm_tx_.operationtx.md) in bytes.
 
@@ -173,7 +173,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L69)*
+*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L69)*
 
 Returns the Buffer representation of the BlockchainID
 
@@ -187,7 +187,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L76)*
+*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L76)*
 
 Returns the array of [TransferableInput](_apis_avm_inputs_.transferableinput.md)s
 
@@ -201,7 +201,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L62)*
+*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L62)*
 
 Returns the NetworkID as a number
 
@@ -213,7 +213,7 @@ ___
 
 ▸ **getOperations**(): *Array‹[TransferableOperation](_apis_avm_ops_.transferableoperation.md)›*
 
-*Defined in [apis/avm/tx.ts:389](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L389)*
+*Defined in [apis/avm/tx.ts:389](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L389)*
 
 Returns an array of [Operation](_apis_avm_ops_.operation.md)s in this transaction.
 
@@ -227,7 +227,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L83)*
+*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L83)*
 
 Returns the array of [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s
 
@@ -241,7 +241,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[getTxType](_apis_avm_tx_.basetx.md#gettxtype)*
 
-*Defined in [apis/avm/tx.ts:348](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L348)*
+*Defined in [apis/avm/tx.ts:348](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L348)*
 
 Returns the id of the [OperationTx](_apis_avm_tx_.operationtx.md)
 
@@ -255,7 +255,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[sign](_apis_avm_tx_.basetx.md#sign)*
 
-*Defined in [apis/avm/tx.ts:401](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L401)*
+*Defined in [apis/avm/tx.ts:401](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L401)*
 
 Takes the bytes of an [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns an array of [Credential](_apis_avm_credentials_.credential.md)s
 
@@ -278,7 +278,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[toBuffer](_apis_avm_tx_.basetx.md#tobuffer)*
 
-*Defined in [apis/avm/tx.ts:377](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L377)*
+*Defined in [apis/avm/tx.ts:377](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L377)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [OperationTx](_apis_avm_tx_.operationtx.md).
 
@@ -292,7 +292,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[toString](_apis_avm_tx_.basetx.md#tostring)*
 
-*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L152)*
+*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L152)*
 
 Returns a base-58 representation of the [BaseTx](_apis_avm_tx_.basetx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.operationtx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.operationtx.md
@@ -48,7 +48,7 @@ Class representing an unsigned Operation transaction.
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[constructor](_apis_avm_tx_.basetx.md#constructor)*
 
-*Defined in [apis/avm/tx.ts:416](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L416)*
+*Defined in [apis/avm/tx.ts:416](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L416)*
 
 Class representing an unsigned Operation transaction.
 
@@ -72,7 +72,7 @@ Name | Type | Default | Description |
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[blockchainid](_apis_avm_tx_.basetx.md#protected-blockchainid)*
 
-*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L46)*
+*Defined in [apis/avm/tx.ts:46](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L46)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[ins](_apis_avm_tx_.basetx.md#protected-ins)*
 
-*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L50)*
+*Defined in [apis/avm/tx.ts:50](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L50)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[networkid](_apis_avm_tx_.basetx.md#protected-networkid)*
 
-*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L45)*
+*Defined in [apis/avm/tx.ts:45](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L45)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 • **numOps**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/tx.ts:342](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L342)*
+*Defined in [apis/avm/tx.ts:342](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L342)*
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[numins](_apis_avm_tx_.basetx.md#protected-numins)*
 
-*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L49)*
+*Defined in [apis/avm/tx.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L49)*
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[numouts](_apis_avm_tx_.basetx.md#protected-numouts)*
 
-*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L47)*
+*Defined in [apis/avm/tx.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L47)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 • **ops**: *Array‹[TransferableOperation](_apis_avm_ops_.transferableoperation.md)›* =  []
 
-*Defined in [apis/avm/tx.ts:343](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L343)*
+*Defined in [apis/avm/tx.ts:343](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L343)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[outs](_apis_avm_tx_.basetx.md#protected-outs)*
 
-*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L48)*
+*Defined in [apis/avm/tx.ts:48](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L48)*
 
 ## Methods
 
@@ -148,7 +148,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[fromBuffer](_apis_avm_tx_.basetx.md#frombuffer)*
 
-*Defined in [apis/avm/tx.ts:361](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L361)*
+*Defined in [apis/avm/tx.ts:361](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L361)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [OperationTx](_apis_avm_tx_.operationtx.md), parses it, populates the class, and returns the length of the [OperationTx](_apis_avm_tx_.operationtx.md) in bytes.
 
@@ -173,7 +173,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L69)*
+*Defined in [apis/avm/tx.ts:69](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L69)*
 
 Returns the Buffer representation of the BlockchainID
 
@@ -187,7 +187,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L76)*
+*Defined in [apis/avm/tx.ts:76](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L76)*
 
 Returns the array of [TransferableInput](_apis_avm_inputs_.transferableinput.md)s
 
@@ -201,7 +201,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L62)*
+*Defined in [apis/avm/tx.ts:62](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L62)*
 
 Returns the NetworkID as a number
 
@@ -213,7 +213,7 @@ ___
 
 ▸ **getOperations**(): *Array‹[TransferableOperation](_apis_avm_ops_.transferableoperation.md)›*
 
-*Defined in [apis/avm/tx.ts:389](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L389)*
+*Defined in [apis/avm/tx.ts:389](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L389)*
 
 Returns an array of [Operation](_apis_avm_ops_.operation.md)s in this transaction.
 
@@ -227,7 +227,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L83)*
+*Defined in [apis/avm/tx.ts:83](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L83)*
 
 Returns the array of [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s
 
@@ -241,7 +241,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[getTxType](_apis_avm_tx_.basetx.md#gettxtype)*
 
-*Defined in [apis/avm/tx.ts:348](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L348)*
+*Defined in [apis/avm/tx.ts:348](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L348)*
 
 Returns the id of the [OperationTx](_apis_avm_tx_.operationtx.md)
 
@@ -255,7 +255,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[sign](_apis_avm_tx_.basetx.md#sign)*
 
-*Defined in [apis/avm/tx.ts:401](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L401)*
+*Defined in [apis/avm/tx.ts:401](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L401)*
 
 Takes the bytes of an [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns an array of [Credential](_apis_avm_credentials_.credential.md)s
 
@@ -278,7 +278,7 @@ ___
 
 *Overrides [BaseTx](_apis_avm_tx_.basetx.md).[toBuffer](_apis_avm_tx_.basetx.md#tobuffer)*
 
-*Defined in [apis/avm/tx.ts:377](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L377)*
+*Defined in [apis/avm/tx.ts:377](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L377)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [OperationTx](_apis_avm_tx_.operationtx.md).
 
@@ -292,7 +292,7 @@ ___
 
 *Inherited from [BaseTx](_apis_avm_tx_.basetx.md).[toString](_apis_avm_tx_.basetx.md#tostring)*
 
-*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L152)*
+*Defined in [apis/avm/tx.ts:152](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L152)*
 
 Returns a base-58 representation of the [BaseTx](_apis_avm_tx_.basetx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.tx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.tx.md
@@ -32,7 +32,7 @@ Class representing a signed transaction.
 
 \+ **new Tx**(`unsignedTx`: [UnsignedTx](_apis_avm_tx_.unsignedtx.md), `credentials`: Array‹[Credential](_apis_avm_credentials_.credential.md)›): *[Tx](_apis_avm_tx_.tx.md)*
 
-*Defined in [apis/avm/tx.ts:563](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L563)*
+*Defined in [apis/avm/tx.ts:563](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L563)*
 
 Class representing a signed transaction.
 
@@ -51,7 +51,7 @@ Name | Type | Default | Description |
 
 • **credentials**: *Array‹[Credential](_apis_avm_credentials_.credential.md)›* =  []
 
-*Defined in [apis/avm/tx.ts:492](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L492)*
+*Defined in [apis/avm/tx.ts:492](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L492)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **unsignedTx**: *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)* =  new UnsignedTx()
 
-*Defined in [apis/avm/tx.ts:491](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L491)*
+*Defined in [apis/avm/tx.ts:491](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L491)*
 
 ## Methods
 
@@ -67,7 +67,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/tx.ts:502](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L502)*
+*Defined in [apis/avm/tx.ts:502](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L502)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [Tx](_apis_avm_tx_.tx.md), parses it, populates the class, and returns the length of the Tx in bytes.
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **fromString**(`serialized`: string): *number*
 
-*Defined in [apis/avm/tx.ts:551](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L551)*
+*Defined in [apis/avm/tx.ts:551](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L551)*
 
 Takes a base-58 string containing an [Tx](_apis_avm_tx_.tx.md), parses it, populates the class, and returns the length of the Tx in bytes.
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:521](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L521)*
+*Defined in [apis/avm/tx.ts:521](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L521)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [Tx](_apis_avm_tx_.tx.md).
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/tx.ts:561](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L561)*
+*Defined in [apis/avm/tx.ts:561](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L561)*
 
 Returns a base-58 AVA-serialized representation of the [Tx](_apis_avm_tx_.tx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.tx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.tx.md
@@ -32,7 +32,7 @@ Class representing a signed transaction.
 
 \+ **new Tx**(`unsignedTx`: [UnsignedTx](_apis_avm_tx_.unsignedtx.md), `credentials`: Array‹[Credential](_apis_avm_credentials_.credential.md)›): *[Tx](_apis_avm_tx_.tx.md)*
 
-*Defined in [apis/avm/tx.ts:563](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L563)*
+*Defined in [apis/avm/tx.ts:563](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L563)*
 
 Class representing a signed transaction.
 
@@ -51,7 +51,7 @@ Name | Type | Default | Description |
 
 • **credentials**: *Array‹[Credential](_apis_avm_credentials_.credential.md)›* =  []
 
-*Defined in [apis/avm/tx.ts:492](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L492)*
+*Defined in [apis/avm/tx.ts:492](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L492)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **unsignedTx**: *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)* =  new UnsignedTx()
 
-*Defined in [apis/avm/tx.ts:491](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L491)*
+*Defined in [apis/avm/tx.ts:491](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L491)*
 
 ## Methods
 
@@ -67,7 +67,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/tx.ts:502](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L502)*
+*Defined in [apis/avm/tx.ts:502](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L502)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [Tx](_apis_avm_tx_.tx.md), parses it, populates the class, and returns the length of the Tx in bytes.
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **fromString**(`serialized`: string): *number*
 
-*Defined in [apis/avm/tx.ts:551](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L551)*
+*Defined in [apis/avm/tx.ts:551](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L551)*
 
 Takes a base-58 string containing an [Tx](_apis_avm_tx_.tx.md), parses it, populates the class, and returns the length of the Tx in bytes.
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:521](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L521)*
+*Defined in [apis/avm/tx.ts:521](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L521)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [Tx](_apis_avm_tx_.tx.md).
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/tx.ts:561](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L561)*
+*Defined in [apis/avm/tx.ts:561](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L561)*
 
 Returns a base-58 AVA-serialized representation of the [Tx](_apis_avm_tx_.tx.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.unsignedtx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.unsignedtx.md
@@ -31,7 +31,7 @@ Class representing an unsigned transaction.
 
 \+ **new UnsignedTx**(`transaction`: [BaseTx](_apis_avm_tx_.basetx.md)): *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)*
 
-*Defined in [apis/avm/tx.ts:480](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L480)*
+*Defined in [apis/avm/tx.ts:480](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L480)*
 
 **Parameters:**
 
@@ -47,7 +47,7 @@ Name | Type | Default |
 
 • **transaction**: *[BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:448](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L448)*
+*Defined in [apis/avm/tx.ts:448](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L448)*
 
 ## Methods
 
@@ -55,7 +55,7 @@ Name | Type | Default |
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/tx.ts:454](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L454)*
+*Defined in [apis/avm/tx.ts:454](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L454)*
 
 **Parameters:**
 
@@ -72,7 +72,7 @@ ___
 
 ▸ **getTransaction**(): *[BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:450](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L450)*
+*Defined in [apis/avm/tx.ts:450](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L450)*
 
 **Returns:** *[BaseTx](_apis_avm_tx_.basetx.md)*
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **sign**(`kc`: [AVMKeyChain](_apis_avm_keychain_.avmkeychain.md)): *[Tx](_apis_avm_tx_.tx.md)*
 
-*Defined in [apis/avm/tx.ts:475](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L475)*
+*Defined in [apis/avm/tx.ts:475](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L475)*
 
 Signs this [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns signed [Tx](_apis_avm_tx_.tx.md)
 
@@ -102,6 +102,6 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:461](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L461)*
+*Defined in [apis/avm/tx.ts:461](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L461)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.unsignedtx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_tx_.unsignedtx.md
@@ -31,7 +31,7 @@ Class representing an unsigned transaction.
 
 \+ **new UnsignedTx**(`transaction`: [BaseTx](_apis_avm_tx_.basetx.md)): *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)*
 
-*Defined in [apis/avm/tx.ts:480](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L480)*
+*Defined in [apis/avm/tx.ts:480](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L480)*
 
 **Parameters:**
 
@@ -47,7 +47,7 @@ Name | Type | Default |
 
 • **transaction**: *[BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:448](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L448)*
+*Defined in [apis/avm/tx.ts:448](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L448)*
 
 ## Methods
 
@@ -55,7 +55,7 @@ Name | Type | Default |
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/tx.ts:454](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L454)*
+*Defined in [apis/avm/tx.ts:454](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L454)*
 
 **Parameters:**
 
@@ -72,7 +72,7 @@ ___
 
 ▸ **getTransaction**(): *[BaseTx](_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:450](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L450)*
+*Defined in [apis/avm/tx.ts:450](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L450)*
 
 **Returns:** *[BaseTx](_apis_avm_tx_.basetx.md)*
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **sign**(`kc`: [AVMKeyChain](_apis_avm_keychain_.avmkeychain.md)): *[Tx](_apis_avm_tx_.tx.md)*
 
-*Defined in [apis/avm/tx.ts:475](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L475)*
+*Defined in [apis/avm/tx.ts:475](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L475)*
 
 Signs this [UnsignedTx](_apis_avm_tx_.unsignedtx.md) and returns signed [Tx](_apis_avm_tx_.tx.md)
 
@@ -102,6 +102,6 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/tx.ts:461](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L461)*
+*Defined in [apis/avm/tx.ts:461](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L461)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.address.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.address.md
@@ -38,7 +38,7 @@ Class for representing an address used in [Output](_apis_avm_outputs_.output.md)
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[constructor](_utils_types_.nbytes.md#constructor)*
 
-*Defined in [apis/avm/types.ts:103](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L103)*
+*Defined in [apis/avm/types.ts:103](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L103)*
 
 Class for representing an address used in [Output](_apis_avm_outputs_.output.md) types
 
@@ -52,7 +52,7 @@ Class for representing an address used in [Output](_apis_avm_outputs_.output.md)
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bsize](_utils_types_.nbytes.md#protected-bsize)*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bytes](_utils_types_.nbytes.md#protected-bytes)*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
 
 ## Methods
 
@@ -72,7 +72,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromBuffer](_utils_types_.nbytes.md#frombuffer)*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -95,7 +95,7 @@ ___
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[fromString](_utils_types_.nbytes.md#fromstring)*
 
-*Defined in [apis/avm/types.ts:87](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L87)*
+*Defined in [apis/avm/types.ts:87](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L87)*
 
 Takes a base-58 string containing an [Address](_apis_avm_types_.address.md), parses it, populates the class, and returns the length of the Address in bytes.
 
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -133,7 +133,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toBuffer](_utils_types_.nbytes.md#tobuffer)*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -149,7 +149,7 @@ ___
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[toString](_utils_types_.nbytes.md#tostring)*
 
-*Defined in [apis/avm/types.ts:77](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L77)*
+*Defined in [apis/avm/types.ts:77](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L77)*
 
 Returns a base-58 representation of the [Address](_apis_avm_types_.address.md).
 
@@ -161,7 +161,7 @@ ___
 
 ▸ **comparitor**(): *function*
 
-*Defined in [apis/avm/types.ts:69](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L69)*
+*Defined in [apis/avm/types.ts:69](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L69)*
 
 Returns a function used to sort an array of [Address](_apis_avm_types_.address.md)es
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.address.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.address.md
@@ -38,7 +38,7 @@ Class for representing an address used in [Output](_apis_avm_outputs_.output.md)
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[constructor](_utils_types_.nbytes.md#constructor)*
 
-*Defined in [apis/avm/types.ts:103](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L103)*
+*Defined in [apis/avm/types.ts:103](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L103)*
 
 Class for representing an address used in [Output](_apis_avm_outputs_.output.md) types
 
@@ -52,7 +52,7 @@ Class for representing an address used in [Output](_apis_avm_outputs_.output.md)
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bsize](_utils_types_.nbytes.md#protected-bsize)*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L400)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bytes](_utils_types_.nbytes.md#protected-bytes)*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L399)*
 
 ## Methods
 
@@ -72,7 +72,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromBuffer](_utils_types_.nbytes.md#frombuffer)*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -95,7 +95,7 @@ ___
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[fromString](_utils_types_.nbytes.md#fromstring)*
 
-*Defined in [apis/avm/types.ts:87](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L87)*
+*Defined in [apis/avm/types.ts:87](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L87)*
 
 Takes a base-58 string containing an [Address](_apis_avm_types_.address.md), parses it, populates the class, and returns the length of the Address in bytes.
 
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -133,7 +133,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toBuffer](_utils_types_.nbytes.md#tobuffer)*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -149,7 +149,7 @@ ___
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[toString](_utils_types_.nbytes.md#tostring)*
 
-*Defined in [apis/avm/types.ts:77](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L77)*
+*Defined in [apis/avm/types.ts:77](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L77)*
 
 Returns a base-58 representation of the [Address](_apis_avm_types_.address.md).
 
@@ -161,7 +161,7 @@ ___
 
 ▸ **comparitor**(): *function*
 
-*Defined in [apis/avm/types.ts:69](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L69)*
+*Defined in [apis/avm/types.ts:69](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L69)*
 
 Returns a function used to sort an array of [Address](_apis_avm_types_.address.md)es
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.avmconstants.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.avmconstants.md
@@ -32,7 +32,7 @@
 
 ▪ **ADDRESSLENGTH**: *number* = 20
 
-*Defined in [apis/avm/types.ts:260](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L260)*
+*Defined in [apis/avm/types.ts:260](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L260)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 ▪ **ASSETIDLEN**: *number* = 32
 
-*Defined in [apis/avm/types.ts:256](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L256)*
+*Defined in [apis/avm/types.ts:256](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L256)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 ▪ **ASSETNAMELEN**: *number* = 128
 
-*Defined in [apis/avm/types.ts:259](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L259)*
+*Defined in [apis/avm/types.ts:259](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L259)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 ▪ **BASETX**: *number* = 0
 
-*Defined in [apis/avm/types.ts:249](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L249)*
+*Defined in [apis/avm/types.ts:249](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L249)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 ▪ **BLOCKCHAINIDLEN**: *number* = 32
 
-*Defined in [apis/avm/types.ts:257](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L257)*
+*Defined in [apis/avm/types.ts:257](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L257)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 ▪ **CREATEASSETTX**: *number* = 1
 
-*Defined in [apis/avm/types.ts:250](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L250)*
+*Defined in [apis/avm/types.ts:250](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L250)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 ▪ **NFTCREDENTIAL**: *number* = 16
 
-*Defined in [apis/avm/types.ts:254](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L254)*
+*Defined in [apis/avm/types.ts:254](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L254)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 ▪ **NFTXFEROP**: *number* = 13
 
-*Defined in [apis/avm/types.ts:247](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L247)*
+*Defined in [apis/avm/types.ts:247](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L247)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 ▪ **NFTXFEROUTPUTID**: *number* = 11
 
-*Defined in [apis/avm/types.ts:244](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L244)*
+*Defined in [apis/avm/types.ts:244](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L244)*
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 ▪ **OPERATIONTX**: *number* = 2
 
-*Defined in [apis/avm/types.ts:251](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L251)*
+*Defined in [apis/avm/types.ts:251](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L251)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 ▪ **SECPCREDENTIAL**: *number* = 9
 
-*Defined in [apis/avm/types.ts:253](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L253)*
+*Defined in [apis/avm/types.ts:253](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L253)*
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 ▪ **SECPFXID**: *number* = 0
 
-*Defined in [apis/avm/types.ts:241](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L241)*
+*Defined in [apis/avm/types.ts:241](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L241)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 ▪ **SECPINPUTID**: *number* = 5
 
-*Defined in [apis/avm/types.ts:246](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L246)*
+*Defined in [apis/avm/types.ts:246](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L246)*
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 ▪ **SECPOUTPUTID**: *number* = 7
 
-*Defined in [apis/avm/types.ts:243](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L243)*
+*Defined in [apis/avm/types.ts:243](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L243)*
 
 ___
 
@@ -144,4 +144,4 @@ ___
 
 ▪ **SYMBOLMAXLEN**: *number* = 4
 
-*Defined in [apis/avm/types.ts:258](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L258)*
+*Defined in [apis/avm/types.ts:258](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L258)*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.avmconstants.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.avmconstants.md
@@ -32,7 +32,7 @@
 
 ▪ **ADDRESSLENGTH**: *number* = 20
 
-*Defined in [apis/avm/types.ts:260](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L260)*
+*Defined in [apis/avm/types.ts:260](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L260)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 ▪ **ASSETIDLEN**: *number* = 32
 
-*Defined in [apis/avm/types.ts:256](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L256)*
+*Defined in [apis/avm/types.ts:256](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L256)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 ▪ **ASSETNAMELEN**: *number* = 128
 
-*Defined in [apis/avm/types.ts:259](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L259)*
+*Defined in [apis/avm/types.ts:259](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L259)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 ▪ **BASETX**: *number* = 0
 
-*Defined in [apis/avm/types.ts:249](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L249)*
+*Defined in [apis/avm/types.ts:249](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L249)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 ▪ **BLOCKCHAINIDLEN**: *number* = 32
 
-*Defined in [apis/avm/types.ts:257](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L257)*
+*Defined in [apis/avm/types.ts:257](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L257)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 ▪ **CREATEASSETTX**: *number* = 1
 
-*Defined in [apis/avm/types.ts:250](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L250)*
+*Defined in [apis/avm/types.ts:250](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L250)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 ▪ **NFTCREDENTIAL**: *number* = 16
 
-*Defined in [apis/avm/types.ts:254](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L254)*
+*Defined in [apis/avm/types.ts:254](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L254)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 ▪ **NFTXFEROP**: *number* = 13
 
-*Defined in [apis/avm/types.ts:247](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L247)*
+*Defined in [apis/avm/types.ts:247](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L247)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 ▪ **NFTXFEROUTPUTID**: *number* = 11
 
-*Defined in [apis/avm/types.ts:244](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L244)*
+*Defined in [apis/avm/types.ts:244](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L244)*
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 ▪ **OPERATIONTX**: *number* = 2
 
-*Defined in [apis/avm/types.ts:251](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L251)*
+*Defined in [apis/avm/types.ts:251](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L251)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 ▪ **SECPCREDENTIAL**: *number* = 9
 
-*Defined in [apis/avm/types.ts:253](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L253)*
+*Defined in [apis/avm/types.ts:253](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L253)*
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 ▪ **SECPFXID**: *number* = 0
 
-*Defined in [apis/avm/types.ts:241](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L241)*
+*Defined in [apis/avm/types.ts:241](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L241)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 ▪ **SECPINPUTID**: *number* = 5
 
-*Defined in [apis/avm/types.ts:246](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L246)*
+*Defined in [apis/avm/types.ts:246](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L246)*
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 ▪ **SECPOUTPUTID**: *number* = 7
 
-*Defined in [apis/avm/types.ts:243](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L243)*
+*Defined in [apis/avm/types.ts:243](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L243)*
 
 ___
 
@@ -144,4 +144,4 @@ ___
 
 ▪ **SYMBOLMAXLEN**: *number* = 4
 
-*Defined in [apis/avm/types.ts:258](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L258)*
+*Defined in [apis/avm/types.ts:258](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L258)*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.initialstates.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.initialstates.md
@@ -30,7 +30,7 @@ Class for creating initial output states used in asset creation
 
 \+ **new InitialStates**(): *[InitialStates](_apis_avm_types_.initialstates.md)*
 
-*Defined in [apis/avm/types.ts:235](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L235)*
+*Defined in [apis/avm/types.ts:235](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L235)*
 
 **Returns:** *[InitialStates](_apis_avm_types_.initialstates.md)*
 
@@ -40,7 +40,7 @@ Class for creating initial output states used in asset creation
 
 • **fxs**: *object*
 
-*Defined in [apis/avm/types.ts:173](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L173)*
+*Defined in [apis/avm/types.ts:173](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L173)*
 
 #### Type declaration:
 
@@ -52,7 +52,7 @@ Class for creating initial output states used in asset creation
 
 ▸ **addOutput**(`out`: [Output](_apis_avm_outputs_.output.md), `fxid`: number): *void*
 
-*Defined in [apis/avm/types.ts:180](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L180)*
+*Defined in [apis/avm/types.ts:180](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L180)*
 
 **Parameters:**
 
@@ -69,7 +69,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/types.ts:187](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L187)*
+*Defined in [apis/avm/types.ts:187](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L187)*
 
 **Parameters:**
 
@@ -86,6 +86,6 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/types.ts:212](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L212)*
+*Defined in [apis/avm/types.ts:212](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L212)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.initialstates.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.initialstates.md
@@ -30,7 +30,7 @@ Class for creating initial output states used in asset creation
 
 \+ **new InitialStates**(): *[InitialStates](_apis_avm_types_.initialstates.md)*
 
-*Defined in [apis/avm/types.ts:235](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L235)*
+*Defined in [apis/avm/types.ts:235](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L235)*
 
 **Returns:** *[InitialStates](_apis_avm_types_.initialstates.md)*
 
@@ -40,7 +40,7 @@ Class for creating initial output states used in asset creation
 
 • **fxs**: *object*
 
-*Defined in [apis/avm/types.ts:173](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L173)*
+*Defined in [apis/avm/types.ts:173](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L173)*
 
 #### Type declaration:
 
@@ -52,7 +52,7 @@ Class for creating initial output states used in asset creation
 
 ▸ **addOutput**(`out`: [Output](_apis_avm_outputs_.output.md), `fxid`: number): *void*
 
-*Defined in [apis/avm/types.ts:180](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L180)*
+*Defined in [apis/avm/types.ts:180](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L180)*
 
 **Parameters:**
 
@@ -69,7 +69,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/types.ts:187](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L187)*
+*Defined in [apis/avm/types.ts:187](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L187)*
 
 **Parameters:**
 
@@ -86,6 +86,6 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/types.ts:212](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L212)*
+*Defined in [apis/avm/types.ts:212](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L212)*
 
 **Returns:** *Buffer*

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.sigidx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.sigidx.md
@@ -40,7 +40,7 @@ Type representing a [Signature](_apis_avm_types_.signature.md) index used in [In
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[constructor](_utils_types_.nbytes.md#constructor)*
 
-*Defined in [apis/avm/types.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L34)*
+*Defined in [apis/avm/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L34)*
 
 Type representing a [Signature](_apis_avm_types_.signature.md) index used in [Input](_apis_avm_inputs_.input.md)
 
@@ -54,7 +54,7 @@ Type representing a [Signature](_apis_avm_types_.signature.md) index used in [In
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bsize](_utils_types_.nbytes.md#protected-bsize)*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bytes](_utils_types_.nbytes.md#protected-bytes)*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **source**: *Buffer*
 
-*Defined in [apis/avm/types.ts:20](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L20)*
+*Defined in [apis/avm/types.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L20)*
 
 ## Methods
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromBuffer](_utils_types_.nbytes.md#frombuffer)*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromString](_utils_types_.nbytes.md#fromstring)*
 
-*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L416)*
+*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L416)*
 
 Takes a base-58 encoded string, verifies its length, and stores it.
 
@@ -127,7 +127,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **getSource**(): *Buffer*
 
-*Defined in [apis/avm/types.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L32)*
+*Defined in [apis/avm/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L32)*
 
 Retrieves the source address for the signature
 
@@ -153,7 +153,7 @@ ___
 
 ▸ **setSource**(`address`: Buffer): *void*
 
-*Defined in [apis/avm/types.ts:25](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L25)*
+*Defined in [apis/avm/types.ts:25](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L25)*
 
 Sets the source address for the signature
 
@@ -173,7 +173,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toBuffer](_utils_types_.nbytes.md#tobuffer)*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -189,7 +189,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toString](_utils_types_.nbytes.md#tostring)*
 
-*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L464)*
+*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L464)*
 
 Returns a base-58 string of the stored [Buffer](https://github.com/feross/buffer).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.sigidx.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.sigidx.md
@@ -40,7 +40,7 @@ Type representing a [Signature](_apis_avm_types_.signature.md) index used in [In
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[constructor](_utils_types_.nbytes.md#constructor)*
 
-*Defined in [apis/avm/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L34)*
+*Defined in [apis/avm/types.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L34)*
 
 Type representing a [Signature](_apis_avm_types_.signature.md) index used in [Input](_apis_avm_inputs_.input.md)
 
@@ -54,7 +54,7 @@ Type representing a [Signature](_apis_avm_types_.signature.md) index used in [In
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bsize](_utils_types_.nbytes.md#protected-bsize)*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L400)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bytes](_utils_types_.nbytes.md#protected-bytes)*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L399)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **source**: *Buffer*
 
-*Defined in [apis/avm/types.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L20)*
+*Defined in [apis/avm/types.ts:20](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L20)*
 
 ## Methods
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromBuffer](_utils_types_.nbytes.md#frombuffer)*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromString](_utils_types_.nbytes.md#fromstring)*
 
-*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L416)*
+*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L416)*
 
 Takes a base-58 encoded string, verifies its length, and stores it.
 
@@ -127,7 +127,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **getSource**(): *Buffer*
 
-*Defined in [apis/avm/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L32)*
+*Defined in [apis/avm/types.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L32)*
 
 Retrieves the source address for the signature
 
@@ -153,7 +153,7 @@ ___
 
 ▸ **setSource**(`address`: Buffer): *void*
 
-*Defined in [apis/avm/types.ts:25](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L25)*
+*Defined in [apis/avm/types.ts:25](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L25)*
 
 Sets the source address for the signature
 
@@ -173,7 +173,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toBuffer](_utils_types_.nbytes.md#tobuffer)*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -189,7 +189,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toString](_utils_types_.nbytes.md#tostring)*
 
-*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L464)*
+*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L464)*
 
 Returns a base-58 string of the stored [Buffer](https://github.com/feross/buffer).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.signature.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.signature.md
@@ -37,7 +37,7 @@ Signature for a [Tx](_apis_avm_tx_.tx.md)
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[constructor](_utils_types_.nbytes.md#constructor)*
 
-*Defined in [apis/avm/types.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L49)*
+*Defined in [apis/avm/types.ts:49](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L49)*
 
 Signature for a [Tx](_apis_avm_tx_.tx.md)
 
@@ -51,7 +51,7 @@ Signature for a [Tx](_apis_avm_tx_.tx.md)
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bsize](_utils_types_.nbytes.md#protected-bsize)*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L400)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bytes](_utils_types_.nbytes.md#protected-bytes)*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L399)*
 
 ## Methods
 
@@ -71,7 +71,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromBuffer](_utils_types_.nbytes.md#frombuffer)*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -94,7 +94,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromString](_utils_types_.nbytes.md#fromstring)*
 
-*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L416)*
+*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L416)*
 
 Takes a base-58 encoded string, verifies its length, and stores it.
 
@@ -116,7 +116,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toBuffer](_utils_types_.nbytes.md#tobuffer)*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -148,7 +148,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toString](_utils_types_.nbytes.md#tostring)*
 
-*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L464)*
+*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L464)*
 
 Returns a base-58 string of the stored [Buffer](https://github.com/feross/buffer).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.signature.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.signature.md
@@ -37,7 +37,7 @@ Signature for a [Tx](_apis_avm_tx_.tx.md)
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[constructor](_utils_types_.nbytes.md#constructor)*
 
-*Defined in [apis/avm/types.ts:49](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L49)*
+*Defined in [apis/avm/types.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L49)*
 
 Signature for a [Tx](_apis_avm_tx_.tx.md)
 
@@ -51,7 +51,7 @@ Signature for a [Tx](_apis_avm_tx_.tx.md)
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bsize](_utils_types_.nbytes.md#protected-bsize)*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bytes](_utils_types_.nbytes.md#protected-bytes)*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
 
 ## Methods
 
@@ -71,7 +71,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromBuffer](_utils_types_.nbytes.md#frombuffer)*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -94,7 +94,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromString](_utils_types_.nbytes.md#fromstring)*
 
-*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L416)*
+*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L416)*
 
 Takes a base-58 encoded string, verifies its length, and stores it.
 
@@ -116,7 +116,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toBuffer](_utils_types_.nbytes.md#tobuffer)*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -148,7 +148,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toString](_utils_types_.nbytes.md#tostring)*
 
-*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L464)*
+*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L464)*
 
 Returns a base-58 string of the stored [Buffer](https://github.com/feross/buffer).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.utxoid.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.utxoid.md
@@ -38,7 +38,7 @@ Class for representing a UTXOID used in [[TransferableOp]] types
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[constructor](_utils_types_.nbytes.md#constructor)*
 
-*Defined in [apis/avm/types.ts:157](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L157)*
+*Defined in [apis/avm/types.ts:157](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L157)*
 
 Class for representing a UTXOID used in [[TransferableOp]] types
 
@@ -52,7 +52,7 @@ Class for representing a UTXOID used in [[TransferableOp]] types
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bsize](_utils_types_.nbytes.md#protected-bsize)*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bytes](_utils_types_.nbytes.md#protected-bytes)*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
 
 ## Methods
 
@@ -72,7 +72,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromBuffer](_utils_types_.nbytes.md#frombuffer)*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -95,7 +95,7 @@ ___
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[fromString](_utils_types_.nbytes.md#fromstring)*
 
-*Defined in [apis/avm/types.ts:141](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L141)*
+*Defined in [apis/avm/types.ts:141](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L141)*
 
 Takes a base-58 string containing an [UTXOID](_apis_avm_types_.utxoid.md), parses it, populates the class, and returns the length of the UTXOID in bytes.
 
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -133,7 +133,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toBuffer](_utils_types_.nbytes.md#tobuffer)*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -149,7 +149,7 @@ ___
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[toString](_utils_types_.nbytes.md#tostring)*
 
-*Defined in [apis/avm/types.ts:131](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L131)*
+*Defined in [apis/avm/types.ts:131](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L131)*
 
 Returns a base-58 representation of the [UTXOID](_apis_avm_types_.utxoid.md).
 
@@ -161,7 +161,7 @@ ___
 
 ▸ **comparitor**(): *function*
 
-*Defined in [apis/avm/types.ts:123](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L123)*
+*Defined in [apis/avm/types.ts:123](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L123)*
 
 Returns a function used to sort an array of [UTXOID](_apis_avm_types_.utxoid.md)s
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.utxoid.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_types_.utxoid.md
@@ -38,7 +38,7 @@ Class for representing a UTXOID used in [[TransferableOp]] types
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[constructor](_utils_types_.nbytes.md#constructor)*
 
-*Defined in [apis/avm/types.ts:157](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L157)*
+*Defined in [apis/avm/types.ts:157](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L157)*
 
 Class for representing a UTXOID used in [[TransferableOp]] types
 
@@ -52,7 +52,7 @@ Class for representing a UTXOID used in [[TransferableOp]] types
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bsize](_utils_types_.nbytes.md#protected-bsize)*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L400)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[bytes](_utils_types_.nbytes.md#protected-bytes)*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L399)*
 
 ## Methods
 
@@ -72,7 +72,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[fromBuffer](_utils_types_.nbytes.md#frombuffer)*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -95,7 +95,7 @@ ___
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[fromString](_utils_types_.nbytes.md#fromstring)*
 
-*Defined in [apis/avm/types.ts:141](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L141)*
+*Defined in [apis/avm/types.ts:141](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L141)*
 
 Takes a base-58 string containing an [UTXOID](_apis_avm_types_.utxoid.md), parses it, populates the class, and returns the length of the UTXOID in bytes.
 
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -133,7 +133,7 @@ ___
 
 *Inherited from [NBytes](_utils_types_.nbytes.md).[toBuffer](_utils_types_.nbytes.md#tobuffer)*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -149,7 +149,7 @@ ___
 
 *Overrides [NBytes](_utils_types_.nbytes.md).[toString](_utils_types_.nbytes.md#tostring)*
 
-*Defined in [apis/avm/types.ts:131](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L131)*
+*Defined in [apis/avm/types.ts:131](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L131)*
 
 Returns a base-58 representation of the [UTXOID](_apis_avm_types_.utxoid.md).
 
@@ -161,7 +161,7 @@ ___
 
 ▸ **comparitor**(): *function*
 
-*Defined in [apis/avm/types.ts:123](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L123)*
+*Defined in [apis/avm/types.ts:123](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L123)*
 
 Returns a function used to sort an array of [UTXOID](_apis_avm_types_.utxoid.md)s
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_utxos_.utxo.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_utxos_.utxo.md
@@ -39,7 +39,7 @@ Class for representing a single UTXO.
 
 \+ **new UTXO**(`txid`: Buffer, `outputidx`: Buffer | number, `assetid`: Buffer, `output`: [Output](_apis_avm_outputs_.output.md)): *[UTXO](_apis_avm_utxos_.utxo.md)*
 
-*Defined in [apis/avm/utxos.ts:121](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L121)*
+*Defined in [apis/avm/utxos.ts:121](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L121)*
 
 Class for representing a single UTXO.
 
@@ -60,7 +60,7 @@ Name | Type | Default | Description |
 
 • **assetid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/utxos.ts:25](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L25)*
+*Defined in [apis/avm/utxos.ts:25](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L25)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **output**: *[Output](_apis_avm_outputs_.output.md)* =  undefined
 
-*Defined in [apis/avm/utxos.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L26)*
+*Defined in [apis/avm/utxos.ts:26](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L26)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **outputidx**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/utxos.ts:24](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L24)*
+*Defined in [apis/avm/utxos.ts:24](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L24)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • **txid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/utxos.ts:23](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L23)*
+*Defined in [apis/avm/utxos.ts:23](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L23)*
 
 ## Methods
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/utxos.ts:73](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L73)*
+*Defined in [apis/avm/utxos.ts:73](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L73)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [UTXO](_apis_avm_utxos_.utxo.md), parses it, populates the class, and returns the length of the UTXO in bytes.
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **fromString**(`serialized`: string): *number*
 
-*Defined in [apis/avm/utxos.ts:107](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L107)*
+*Defined in [apis/avm/utxos.ts:107](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L107)*
 
 Takes a base-58 string containing an [UTXO](_apis_avm_utxos_.utxo.md), parses it, populates the class, and returns the length of the UTXO in bytes.
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **getAssetID**(): *Buffer*
 
-*Defined in [apis/avm/utxos.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L47)*
+*Defined in [apis/avm/utxos.ts:47](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L47)*
 
 Returns the assetID as a [Buffer](https://github.com/feross/buffer).
 
@@ -146,7 +146,7 @@ ___
 
 ▸ **getOutput**(): *[Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/utxos.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L63)*
+*Defined in [apis/avm/utxos.ts:63](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L63)*
 
 Returns a reference to the output;
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **getOutputIdx**(): *Buffer*
 
-*Defined in [apis/avm/utxos.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L39)*
+*Defined in [apis/avm/utxos.ts:39](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L39)*
 
 Returns a [Buffer](https://github.com/feross/buffer)  of the OutputIdx.
 
@@ -170,7 +170,7 @@ ___
 
 ▸ **getTxID**(): *Buffer*
 
-*Defined in [apis/avm/utxos.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L31)*
+*Defined in [apis/avm/utxos.ts:31](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L31)*
 
 Returns a [Buffer](https://github.com/feross/buffer) of the TxID.
 
@@ -182,7 +182,7 @@ ___
 
 ▸ **getUTXOID**(): *string*
 
-*Defined in [apis/avm/utxos.ts:54](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L54)*
+*Defined in [apis/avm/utxos.ts:54](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L54)*
 
 Returns the UTXOID as a base-58 string (UTXOID is a string )
 
@@ -194,7 +194,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/utxos.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L89)*
+*Defined in [apis/avm/utxos.ts:89](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L89)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [UTXO](_apis_avm_utxos_.utxo.md).
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/utxos.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L118)*
+*Defined in [apis/avm/utxos.ts:118](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L118)*
 
 Returns a base-58 representation of the [UTXO](_apis_avm_utxos_.utxo.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_utxos_.utxo.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_utxos_.utxo.md
@@ -39,7 +39,7 @@ Class for representing a single UTXO.
 
 \+ **new UTXO**(`txid`: Buffer, `outputidx`: Buffer | number, `assetid`: Buffer, `output`: [Output](_apis_avm_outputs_.output.md)): *[UTXO](_apis_avm_utxos_.utxo.md)*
 
-*Defined in [apis/avm/utxos.ts:121](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L121)*
+*Defined in [apis/avm/utxos.ts:121](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L121)*
 
 Class for representing a single UTXO.
 
@@ -60,7 +60,7 @@ Name | Type | Default | Description |
 
 • **assetid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/utxos.ts:25](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L25)*
+*Defined in [apis/avm/utxos.ts:25](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L25)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **output**: *[Output](_apis_avm_outputs_.output.md)* =  undefined
 
-*Defined in [apis/avm/utxos.ts:26](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L26)*
+*Defined in [apis/avm/utxos.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L26)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **outputidx**: *Buffer* =  Buffer.alloc(4)
 
-*Defined in [apis/avm/utxos.ts:24](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L24)*
+*Defined in [apis/avm/utxos.ts:24](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L24)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • **txid**: *Buffer* =  Buffer.alloc(32)
 
-*Defined in [apis/avm/utxos.ts:23](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L23)*
+*Defined in [apis/avm/utxos.ts:23](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L23)*
 
 ## Methods
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **fromBuffer**(`bytes`: Buffer, `offset`: number): *number*
 
-*Defined in [apis/avm/utxos.ts:73](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L73)*
+*Defined in [apis/avm/utxos.ts:73](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L73)*
 
 Takes a [Buffer](https://github.com/feross/buffer) containing an [UTXO](_apis_avm_utxos_.utxo.md), parses it, populates the class, and returns the length of the UTXO in bytes.
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **fromString**(`serialized`: string): *number*
 
-*Defined in [apis/avm/utxos.ts:107](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L107)*
+*Defined in [apis/avm/utxos.ts:107](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L107)*
 
 Takes a base-58 string containing an [UTXO](_apis_avm_utxos_.utxo.md), parses it, populates the class, and returns the length of the UTXO in bytes.
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **getAssetID**(): *Buffer*
 
-*Defined in [apis/avm/utxos.ts:47](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L47)*
+*Defined in [apis/avm/utxos.ts:47](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L47)*
 
 Returns the assetID as a [Buffer](https://github.com/feross/buffer).
 
@@ -146,7 +146,7 @@ ___
 
 ▸ **getOutput**(): *[Output](_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/utxos.ts:63](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L63)*
+*Defined in [apis/avm/utxos.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L63)*
 
 Returns a reference to the output;
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **getOutputIdx**(): *Buffer*
 
-*Defined in [apis/avm/utxos.ts:39](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L39)*
+*Defined in [apis/avm/utxos.ts:39](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L39)*
 
 Returns a [Buffer](https://github.com/feross/buffer)  of the OutputIdx.
 
@@ -170,7 +170,7 @@ ___
 
 ▸ **getTxID**(): *Buffer*
 
-*Defined in [apis/avm/utxos.ts:31](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L31)*
+*Defined in [apis/avm/utxos.ts:31](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L31)*
 
 Returns a [Buffer](https://github.com/feross/buffer) of the TxID.
 
@@ -182,7 +182,7 @@ ___
 
 ▸ **getUTXOID**(): *string*
 
-*Defined in [apis/avm/utxos.ts:54](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L54)*
+*Defined in [apis/avm/utxos.ts:54](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L54)*
 
 Returns the UTXOID as a base-58 string (UTXOID is a string )
 
@@ -194,7 +194,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [apis/avm/utxos.ts:89](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L89)*
+*Defined in [apis/avm/utxos.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L89)*
 
 Returns a [Buffer](https://github.com/feross/buffer) representation of the [UTXO](_apis_avm_utxos_.utxo.md).
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [apis/avm/utxos.ts:118](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L118)*
+*Defined in [apis/avm/utxos.ts:118](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L118)*
 
 Returns a base-58 representation of the [UTXO](_apis_avm_utxos_.utxo.md).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_utxos_.utxoset.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_utxos_.utxoset.md
@@ -45,7 +45,7 @@ Class representing a set of [UTXO](_apis_avm_utxos_.utxo.md)s.
 
 • **addressUTXOs**: *object*
 
-*Defined in [apis/avm/utxos.ts:154](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L154)*
+*Defined in [apis/avm/utxos.ts:154](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L154)*
 
 #### Type declaration:
 
@@ -59,7 +59,7 @@ ___
 
 • **utxos**: *object*
 
-*Defined in [apis/avm/utxos.ts:153](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L153)*
+*Defined in [apis/avm/utxos.ts:153](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L153)*
 
 #### Type declaration:
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **add**(`utxo`: [UTXO](_apis_avm_utxos_.utxo.md) | string, `overwrite`: boolean): *[UTXO](_apis_avm_utxos_.utxo.md)*
 
-*Defined in [apis/avm/utxos.ts:181](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L181)*
+*Defined in [apis/avm/utxos.ts:181](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L181)*
 
 Adds a UTXO to the UTXOSet.
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **addArray**(`utxos`: Array‹string | [UTXO](_apis_avm_utxos_.utxo.md)›, `overwrite`: boolean): *Array‹[UTXO](_apis_avm_utxos_.utxo.md)›*
 
-*Defined in [apis/avm/utxos.ts:218](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L218)*
+*Defined in [apis/avm/utxos.ts:218](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L218)*
 
 Adds an array of [UTXO](_apis_avm_utxos_.utxo.md)s to the [UTXOSet](_apis_avm_utxos_.utxoset.md).
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **difference**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:656](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L656)*
+*Defined in [apis/avm/utxos.ts:656](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L656)*
 
 Set difference between this set and a parameter.
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **getAddresses**(): *Array‹Buffer›*
 
-*Defined in [apis/avm/utxos.ts:363](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L363)*
+*Defined in [apis/avm/utxos.ts:363](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L363)*
 
 Gets the addresses in the [UTXOSet](_apis_avm_utxos_.utxoset.md) and returns an array of [Buffer](https://github.com/feross/buffer).
 
@@ -145,7 +145,7 @@ ___
 
 ▸ **getAllUTXOStrings**(`utxoids`: Array‹string›): *Array‹string›*
 
-*Defined in [apis/avm/utxos.ts:316](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L316)*
+*Defined in [apis/avm/utxos.ts:316](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L316)*
 
 Gets all the [UTXO](_apis_avm_utxos_.utxo.md)s as strings, optionally that match with UTXOIDs in an array.
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **getAllUTXOs**(`utxoids`: Array‹string›): *Array‹[UTXO](_apis_avm_utxos_.utxo.md)›*
 
-*Defined in [apis/avm/utxos.ts:295](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L295)*
+*Defined in [apis/avm/utxos.ts:295](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L295)*
 
 Gets all the [UTXO](_apis_avm_utxos_.utxo.md)s, optionally that match with UTXOIDs in an array
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getAssetIDs**(`addresses`: Array‹Buffer›): *Array‹Buffer›*
 
-*Defined in [apis/avm/utxos.ts:401](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L401)*
+*Defined in [apis/avm/utxos.ts:401](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L401)*
 
 Gets all the Asset IDs, optionally that match with Asset IDs in an array
 
@@ -205,7 +205,7 @@ ___
 
 ▸ **getBalance**(`addresses`: Array‹Buffer›, `assetID`: Buffer | string, `asOf`: BN): *BN*
 
-*Defined in [apis/avm/utxos.ts:376](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L376)*
+*Defined in [apis/avm/utxos.ts:376](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L376)*
 
 Returns the balance of a set of addresses in the UTXOSet.
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **getUTXO**(`utxoid`: string): *[UTXO](_apis_avm_utxos_.utxo.md)*
 
-*Defined in [apis/avm/utxos.ts:284](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L284)*
+*Defined in [apis/avm/utxos.ts:284](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L284)*
 
 Gets a [UTXO](_apis_avm_utxos_.utxo.md) from the [UTXOSet](_apis_avm_utxos_.utxoset.md) by its UTXOID.
 
@@ -247,7 +247,7 @@ ___
 
 ▸ **getUTXOIDs**(`addresses`: Array‹Buffer›, `spendable`: boolean): *Array‹string›*
 
-*Defined in [apis/avm/utxos.ts:341](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L341)*
+*Defined in [apis/avm/utxos.ts:341](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L341)*
 
 Given an address or array of addresses, returns all the UTXOIDs for those addresses
 
@@ -268,7 +268,7 @@ ___
 
 ▸ **includes**(`utxo`: [UTXO](_apis_avm_utxos_.utxo.md) | string): *boolean*
 
-*Defined in [apis/avm/utxos.ts:161](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L161)*
+*Defined in [apis/avm/utxos.ts:161](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L161)*
 
 Returns true if the [UTXO](_apis_avm_utxos_.utxo.md) is in the UTXOSet.
 
@@ -286,7 +286,7 @@ ___
 
 ▸ **intersection**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:641](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L641)*
+*Defined in [apis/avm/utxos.ts:641](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L641)*
 
 Set intersetion between this set and a parameter.
 
@@ -306,7 +306,7 @@ ___
 
 ▸ **makeBaseTx**(`networkid`: number, `blockchainid`: Buffer, `amount`: BN, `toAddresses`: Array‹Buffer›, `fromAddresses`: Array‹Buffer›, `changeAddresses`: Array‹Buffer›, `assetID`: Buffer, `asOf`: BN, `locktime`: BN, `threshold`: number, `outputID`: number): *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)*
 
-*Defined in [apis/avm/utxos.ts:438](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L438)*
+*Defined in [apis/avm/utxos.ts:438](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L438)*
 
 Creates an [UnsignedTx](_apis_avm_tx_.unsignedtx.md) wrapping a [BaseTx](_apis_avm_tx_.basetx.md). For more granular control, you may create your own
 [UnsignedTx](_apis_avm_tx_.unsignedtx.md) wrapping a [BaseTx](_apis_avm_tx_.basetx.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s and [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s).
@@ -337,7 +337,7 @@ ___
 
 ▸ **makeCreateAssetTx**(`networkid`: number, `blockchainid`: Buffer, `avaAssetID`: Buffer, `fee`: BN, `feeSenderAddresses`: Array‹Buffer›, `initialState`: [InitialStates](_apis_avm_types_.initialstates.md), `name`: string, `symbol`: string, `denomination`: number): *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)*
 
-*Defined in [apis/avm/utxos.ts:538](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L538)*
+*Defined in [apis/avm/utxos.ts:538](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L538)*
 
 Creates an unsigned transaction. For more granular control, you may create your own
 [[TxCreateAsset]] manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s).
@@ -366,7 +366,7 @@ ___
 
 ▸ **makeNFTTransferTx**(`networkid`: number, `blockchainid`: Buffer, `feeAssetID`: Buffer, `fee`: BN, `feeSenderAddresses`: Array‹Buffer›, `toAddresses`: Array‹Buffer›, `fromAddresses`: Array‹Buffer›, `utxoids`: Array‹string›, `asOf`: BN, `locktime`: BN, `threshold`: number): *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)*
 
-*Defined in [apis/avm/utxos.ts:571](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L571)*
+*Defined in [apis/avm/utxos.ts:571](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L571)*
 
 Creates an unsigned NFT transfer transaction. For more granular control, you may create your own
 [NFTTransferOperation](_apis_avm_ops_.nfttransferoperation.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s, and [[TransferOperation]]s).
@@ -397,7 +397,7 @@ ___
 
 ▸ **merge**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `hasUTXOIDs`: Array‹string›): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:622](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L622)*
+*Defined in [apis/avm/utxos.ts:622](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L622)*
 
 Returns a new set with copy of UTXOs in this and set parameter.
 
@@ -418,7 +418,7 @@ ___
 
 ▸ **mergeByRule**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `mergeRule`: [MergeRule](../modules/_apis_avm_types_.md#mergerule)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:709](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L709)*
+*Defined in [apis/avm/utxos.ts:709](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L709)*
 
 Merges a set by the rule provided.
 
@@ -439,7 +439,7 @@ ___
 
 ▸ **remove**(`utxo`: [UTXO](_apis_avm_utxos_.utxo.md) | string): *[UTXO](_apis_avm_utxos_.utxo.md)*
 
-*Defined in [apis/avm/utxos.ts:236](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L236)*
+*Defined in [apis/avm/utxos.ts:236](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L236)*
 
 Removes a [UTXO](_apis_avm_utxos_.utxo.md) from the [UTXOSet](_apis_avm_utxos_.utxoset.md) if it exists.
 
@@ -459,7 +459,7 @@ ___
 
 ▸ **removeArray**(`utxos`: Array‹string | [UTXO](_apis_avm_utxos_.utxo.md)›): *Array‹[UTXO](_apis_avm_utxos_.utxo.md)›*
 
-*Defined in [apis/avm/utxos.ts:266](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L266)*
+*Defined in [apis/avm/utxos.ts:266](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L266)*
 
 Removes an array of [UTXO](_apis_avm_utxos_.utxo.md)s to the [UTXOSet](_apis_avm_utxos_.utxoset.md).
 
@@ -479,7 +479,7 @@ ___
 
 ▸ **symDifference**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:671](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L671)*
+*Defined in [apis/avm/utxos.ts:671](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L671)*
 
 Set symmetrical difference between this set and a parameter.
 
@@ -499,7 +499,7 @@ ___
 
 ▸ **union**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:687](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L687)*
+*Defined in [apis/avm/utxos.ts:687](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/utxos.ts#L687)*
 
 Set union between this set and a parameter.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_utxos_.utxoset.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_avm_utxos_.utxoset.md
@@ -45,7 +45,7 @@ Class representing a set of [UTXO](_apis_avm_utxos_.utxo.md)s.
 
 • **addressUTXOs**: *object*
 
-*Defined in [apis/avm/utxos.ts:154](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L154)*
+*Defined in [apis/avm/utxos.ts:154](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L154)*
 
 #### Type declaration:
 
@@ -59,7 +59,7 @@ ___
 
 • **utxos**: *object*
 
-*Defined in [apis/avm/utxos.ts:153](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L153)*
+*Defined in [apis/avm/utxos.ts:153](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L153)*
 
 #### Type declaration:
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **add**(`utxo`: [UTXO](_apis_avm_utxos_.utxo.md) | string, `overwrite`: boolean): *[UTXO](_apis_avm_utxos_.utxo.md)*
 
-*Defined in [apis/avm/utxos.ts:181](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L181)*
+*Defined in [apis/avm/utxos.ts:181](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L181)*
 
 Adds a UTXO to the UTXOSet.
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **addArray**(`utxos`: Array‹string | [UTXO](_apis_avm_utxos_.utxo.md)›, `overwrite`: boolean): *Array‹[UTXO](_apis_avm_utxos_.utxo.md)›*
 
-*Defined in [apis/avm/utxos.ts:218](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L218)*
+*Defined in [apis/avm/utxos.ts:218](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L218)*
 
 Adds an array of [UTXO](_apis_avm_utxos_.utxo.md)s to the [UTXOSet](_apis_avm_utxos_.utxoset.md).
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **difference**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:656](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L656)*
+*Defined in [apis/avm/utxos.ts:656](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L656)*
 
 Set difference between this set and a parameter.
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **getAddresses**(): *Array‹Buffer›*
 
-*Defined in [apis/avm/utxos.ts:363](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L363)*
+*Defined in [apis/avm/utxos.ts:363](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L363)*
 
 Gets the addresses in the [UTXOSet](_apis_avm_utxos_.utxoset.md) and returns an array of [Buffer](https://github.com/feross/buffer).
 
@@ -145,7 +145,7 @@ ___
 
 ▸ **getAllUTXOStrings**(`utxoids`: Array‹string›): *Array‹string›*
 
-*Defined in [apis/avm/utxos.ts:316](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L316)*
+*Defined in [apis/avm/utxos.ts:316](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L316)*
 
 Gets all the [UTXO](_apis_avm_utxos_.utxo.md)s as strings, optionally that match with UTXOIDs in an array.
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **getAllUTXOs**(`utxoids`: Array‹string›): *Array‹[UTXO](_apis_avm_utxos_.utxo.md)›*
 
-*Defined in [apis/avm/utxos.ts:295](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L295)*
+*Defined in [apis/avm/utxos.ts:295](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L295)*
 
 Gets all the [UTXO](_apis_avm_utxos_.utxo.md)s, optionally that match with UTXOIDs in an array
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getAssetIDs**(`addresses`: Array‹Buffer›): *Array‹Buffer›*
 
-*Defined in [apis/avm/utxos.ts:401](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L401)*
+*Defined in [apis/avm/utxos.ts:401](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L401)*
 
 Gets all the Asset IDs, optionally that match with Asset IDs in an array
 
@@ -205,7 +205,7 @@ ___
 
 ▸ **getBalance**(`addresses`: Array‹Buffer›, `assetID`: Buffer | string, `asOf`: BN): *BN*
 
-*Defined in [apis/avm/utxos.ts:376](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L376)*
+*Defined in [apis/avm/utxos.ts:376](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L376)*
 
 Returns the balance of a set of addresses in the UTXOSet.
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **getUTXO**(`utxoid`: string): *[UTXO](_apis_avm_utxos_.utxo.md)*
 
-*Defined in [apis/avm/utxos.ts:284](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L284)*
+*Defined in [apis/avm/utxos.ts:284](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L284)*
 
 Gets a [UTXO](_apis_avm_utxos_.utxo.md) from the [UTXOSet](_apis_avm_utxos_.utxoset.md) by its UTXOID.
 
@@ -247,7 +247,7 @@ ___
 
 ▸ **getUTXOIDs**(`addresses`: Array‹Buffer›, `spendable`: boolean): *Array‹string›*
 
-*Defined in [apis/avm/utxos.ts:341](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L341)*
+*Defined in [apis/avm/utxos.ts:341](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L341)*
 
 Given an address or array of addresses, returns all the UTXOIDs for those addresses
 
@@ -268,7 +268,7 @@ ___
 
 ▸ **includes**(`utxo`: [UTXO](_apis_avm_utxos_.utxo.md) | string): *boolean*
 
-*Defined in [apis/avm/utxos.ts:161](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L161)*
+*Defined in [apis/avm/utxos.ts:161](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L161)*
 
 Returns true if the [UTXO](_apis_avm_utxos_.utxo.md) is in the UTXOSet.
 
@@ -286,7 +286,7 @@ ___
 
 ▸ **intersection**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:641](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L641)*
+*Defined in [apis/avm/utxos.ts:641](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L641)*
 
 Set intersetion between this set and a parameter.
 
@@ -306,7 +306,7 @@ ___
 
 ▸ **makeBaseTx**(`networkid`: number, `blockchainid`: Buffer, `amount`: BN, `toAddresses`: Array‹Buffer›, `fromAddresses`: Array‹Buffer›, `changeAddresses`: Array‹Buffer›, `assetID`: Buffer, `asOf`: BN, `locktime`: BN, `threshold`: number, `outputID`: number): *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)*
 
-*Defined in [apis/avm/utxos.ts:438](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L438)*
+*Defined in [apis/avm/utxos.ts:438](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L438)*
 
 Creates an [UnsignedTx](_apis_avm_tx_.unsignedtx.md) wrapping a [BaseTx](_apis_avm_tx_.basetx.md). For more granular control, you may create your own
 [UnsignedTx](_apis_avm_tx_.unsignedtx.md) wrapping a [BaseTx](_apis_avm_tx_.basetx.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s and [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s).
@@ -337,7 +337,7 @@ ___
 
 ▸ **makeCreateAssetTx**(`networkid`: number, `blockchainid`: Buffer, `avaAssetID`: Buffer, `fee`: BN, `feeSenderAddresses`: Array‹Buffer›, `initialState`: [InitialStates](_apis_avm_types_.initialstates.md), `name`: string, `symbol`: string, `denomination`: number): *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)*
 
-*Defined in [apis/avm/utxos.ts:538](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L538)*
+*Defined in [apis/avm/utxos.ts:538](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L538)*
 
 Creates an unsigned transaction. For more granular control, you may create your own
 [[TxCreateAsset]] manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s).
@@ -366,7 +366,7 @@ ___
 
 ▸ **makeNFTTransferTx**(`networkid`: number, `blockchainid`: Buffer, `feeAssetID`: Buffer, `fee`: BN, `feeSenderAddresses`: Array‹Buffer›, `toAddresses`: Array‹Buffer›, `fromAddresses`: Array‹Buffer›, `utxoids`: Array‹string›, `asOf`: BN, `locktime`: BN, `threshold`: number): *[UnsignedTx](_apis_avm_tx_.unsignedtx.md)*
 
-*Defined in [apis/avm/utxos.ts:571](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L571)*
+*Defined in [apis/avm/utxos.ts:571](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L571)*
 
 Creates an unsigned NFT transfer transaction. For more granular control, you may create your own
 [NFTTransferOperation](_apis_avm_ops_.nfttransferoperation.md) manually (with their corresponding [TransferableInput](_apis_avm_inputs_.transferableinput.md)s, [TransferableOutput](_apis_avm_outputs_.transferableoutput.md)s, and [[TransferOperation]]s).
@@ -397,7 +397,7 @@ ___
 
 ▸ **merge**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `hasUTXOIDs`: Array‹string›): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:622](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L622)*
+*Defined in [apis/avm/utxos.ts:622](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L622)*
 
 Returns a new set with copy of UTXOs in this and set parameter.
 
@@ -418,7 +418,7 @@ ___
 
 ▸ **mergeByRule**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md), `mergeRule`: [MergeRule](../modules/_apis_avm_types_.md#mergerule)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:709](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L709)*
+*Defined in [apis/avm/utxos.ts:709](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L709)*
 
 Merges a set by the rule provided.
 
@@ -439,7 +439,7 @@ ___
 
 ▸ **remove**(`utxo`: [UTXO](_apis_avm_utxos_.utxo.md) | string): *[UTXO](_apis_avm_utxos_.utxo.md)*
 
-*Defined in [apis/avm/utxos.ts:236](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L236)*
+*Defined in [apis/avm/utxos.ts:236](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L236)*
 
 Removes a [UTXO](_apis_avm_utxos_.utxo.md) from the [UTXOSet](_apis_avm_utxos_.utxoset.md) if it exists.
 
@@ -459,7 +459,7 @@ ___
 
 ▸ **removeArray**(`utxos`: Array‹string | [UTXO](_apis_avm_utxos_.utxo.md)›): *Array‹[UTXO](_apis_avm_utxos_.utxo.md)›*
 
-*Defined in [apis/avm/utxos.ts:266](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L266)*
+*Defined in [apis/avm/utxos.ts:266](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L266)*
 
 Removes an array of [UTXO](_apis_avm_utxos_.utxo.md)s to the [UTXOSet](_apis_avm_utxos_.utxoset.md).
 
@@ -479,7 +479,7 @@ ___
 
 ▸ **symDifference**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:671](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L671)*
+*Defined in [apis/avm/utxos.ts:671](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L671)*
 
 Set symmetrical difference between this set and a parameter.
 
@@ -499,7 +499,7 @@ ___
 
 ▸ **union**(`utxoset`: [UTXOSet](_apis_avm_utxos_.utxoset.md)): *[UTXOSet](_apis_avm_utxos_.utxoset.md)*
 
-*Defined in [apis/avm/utxos.ts:687](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/utxos.ts#L687)*
+*Defined in [apis/avm/utxos.ts:687](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/utxos.ts#L687)*
 
 Set union between this set and a parameter.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_keystore_api_.keystoreapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_keystore_api_.keystoreapi.md
@@ -49,7 +49,7 @@ Class for interacting with a node API that is using the node's KeystoreAPI.
 
 *Overrides [JRPCAPI](_utils_types_.jrpcapi.md).[constructor](_utils_types_.jrpcapi.md#constructor)*
 
-*Defined in [apis/keystore/api.ts:101](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/keystore/api.ts#L101)*
+*Defined in [apis/keystore/api.ts:101](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L101)*
 
 This class should not be instantiated directly. Instead use the [Slopes.addAPI](_index_.slopes.md#addapi) method.
 
@@ -70,7 +70,7 @@ Name | Type | Default | Description |
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[jrpcVersion](_utils_types_.jrpcapi.md#protected-jrpcversion)*
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[rpcid](_utils_types_.jrpcapi.md#protected-rpcid)*
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -120,7 +120,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -138,7 +138,7 @@ ___
 
 ▸ **createUser**(`username`: string, `password`: string): *Promise‹boolean›*
 
-*Defined in [apis/keystore/api.ts:26](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/keystore/api.ts#L26)*
+*Defined in [apis/keystore/api.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L26)*
 
 Creates a user in the node's database.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **deleteUser**(`username`: string, `password`: string): *Promise‹boolean›*
 
-*Defined in [apis/keystore/api.ts:93](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/keystore/api.ts#L93)*
+*Defined in [apis/keystore/api.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L93)*
 
 Deletes a user in the node's database.
 
@@ -180,7 +180,7 @@ ___
 
 ▸ **exportUser**(`username`: string, `password`: string): *Promise‹string›*
 
-*Defined in [apis/keystore/api.ts:44](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/keystore/api.ts#L44)*
+*Defined in [apis/keystore/api.ts:44](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L44)*
 
 Exports a user. The user can be imported to another node with keystore.importUser .
 
@@ -203,7 +203,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -217,7 +217,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -231,7 +231,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -243,7 +243,7 @@ ___
 
 ▸ **importUser**(`username`: string, `user`: string, `password`: string): *Promise‹boolean›*
 
-*Defined in [apis/keystore/api.ts:63](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/keystore/api.ts#L63)*
+*Defined in [apis/keystore/api.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L63)*
 
 Imports a user file into the node's user database and assigns it to a username.
 
@@ -265,7 +265,7 @@ ___
 
 ▸ **listUsers**(): *Promise‹Array‹string››*
 
-*Defined in [apis/keystore/api.ts:79](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/keystore/api.ts#L79)*
+*Defined in [apis/keystore/api.ts:79](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L79)*
 
 Lists the names of all users on the node.
 
@@ -281,7 +281,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_keystore_api_.keystoreapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_keystore_api_.keystoreapi.md
@@ -49,7 +49,7 @@ Class for interacting with a node API that is using the node's KeystoreAPI.
 
 *Overrides [JRPCAPI](_utils_types_.jrpcapi.md).[constructor](_utils_types_.jrpcapi.md#constructor)*
 
-*Defined in [apis/keystore/api.ts:101](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L101)*
+*Defined in [apis/keystore/api.ts:101](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/keystore/api.ts#L101)*
 
 This class should not be instantiated directly. Instead use the [Slopes.addAPI](_index_.slopes.md#addapi) method.
 
@@ -70,7 +70,7 @@ Name | Type | Default | Description |
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L33)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L32)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L34)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[jrpcVersion](_utils_types_.jrpcapi.md#protected-jrpcversion)*
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L80)*
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[rpcid](_utils_types_.jrpcapi.md#protected-rpcid)*
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -120,7 +120,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -138,7 +138,7 @@ ___
 
 ▸ **createUser**(`username`: string, `password`: string): *Promise‹boolean›*
 
-*Defined in [apis/keystore/api.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L26)*
+*Defined in [apis/keystore/api.ts:26](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/keystore/api.ts#L26)*
 
 Creates a user in the node's database.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **deleteUser**(`username`: string, `password`: string): *Promise‹boolean›*
 
-*Defined in [apis/keystore/api.ts:93](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L93)*
+*Defined in [apis/keystore/api.ts:93](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/keystore/api.ts#L93)*
 
 Deletes a user in the node's database.
 
@@ -180,7 +180,7 @@ ___
 
 ▸ **exportUser**(`username`: string, `password`: string): *Promise‹string›*
 
-*Defined in [apis/keystore/api.ts:44](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L44)*
+*Defined in [apis/keystore/api.ts:44](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/keystore/api.ts#L44)*
 
 Exports a user. The user can be imported to another node with keystore.importUser .
 
@@ -203,7 +203,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -217,7 +217,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -231,7 +231,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -243,7 +243,7 @@ ___
 
 ▸ **importUser**(`username`: string, `user`: string, `password`: string): *Promise‹boolean›*
 
-*Defined in [apis/keystore/api.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L63)*
+*Defined in [apis/keystore/api.ts:63](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/keystore/api.ts#L63)*
 
 Imports a user file into the node's user database and assigns it to a username.
 
@@ -265,7 +265,7 @@ ___
 
 ▸ **listUsers**(): *Promise‹Array‹string››*
 
-*Defined in [apis/keystore/api.ts:79](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/keystore/api.ts#L79)*
+*Defined in [apis/keystore/api.ts:79](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/keystore/api.ts#L79)*
 
 Lists the names of all users on the node.
 
@@ -281,7 +281,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_platform_api_.platformapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_platform_api_.platformapi.md
@@ -62,7 +62,7 @@ Class for interacting with a node's PlatformAPI
 
 *Overrides [JRPCAPI](_utils_types_.jrpcapi.md).[constructor](_utils_types_.jrpcapi.md#constructor)*
 
-*Defined in [apis/platform/api.ts:438](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L438)*
+*Defined in [apis/platform/api.ts:438](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L438)*
 
 This class should not be instantiated directly. Instead use the [Slopes.addAPI](_index_.slopes.md#addapi) method.
 
@@ -83,7 +83,7 @@ Name | Type | Default | Description |
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[jrpcVersion](_utils_types_.jrpcapi.md#protected-jrpcversion)*
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[rpcid](_utils_types_.jrpcapi.md#protected-rpcid)*
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **addDefaultSubnetDelegator**(`id`: string, `startTime`: Date, `endTime`: Date, `stakeAmount`: BN, `payerNonce`: number, `destination`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:263](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L263)*
+*Defined in [apis/platform/api.ts:263](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L263)*
 
 Add a delegator to the Default Subnet.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **addDefaultSubnetValidator**(`id`: string, `startTime`: Date, `endTime`: Date, `stakeAmount`: BN, `payerNonce`: number, `destination`: string, `delegationFeeRate`: BN): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:203](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L203)*
+*Defined in [apis/platform/api.ts:203](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L203)*
 
 Add a validator to the Default Subnet.
 
@@ -182,7 +182,7 @@ ___
 
 ▸ **addNonDefaultSubnetValidator**(`id`: string, `subnetID`: Buffer | string, `startTime`: Date, `endTime`: Date, `weight`: number, `payerNonce`: number): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:232](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L232)*
+*Defined in [apis/platform/api.ts:232](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L232)*
 
 Add a validator to a Subnet other than the Default Subnet. The validator must validate the Default Subnet for the entire duration they validate this Subnet.
 
@@ -209,7 +209,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **createAccount**(`username`: string, `password`: string, `privateKey`: Buffer | string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:77](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L77)*
+*Defined in [apis/platform/api.ts:77](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L77)*
 
 The P-Chain uses an account model. This method creates a P-Chain account on an existing user in the Keystore.
 
@@ -249,7 +249,7 @@ ___
 
 ▸ **createBlockchain**(`vmID`: string, `name`: string, `payerNonce`: number, `genesis`: string, `subnetID`: Buffer | string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:35](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L35)*
+*Defined in [apis/platform/api.ts:35](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L35)*
 
 Creates a new blockchain.
 
@@ -273,7 +273,7 @@ ___
 
 ▸ **createSubnet**(`controlKeys`: Array‹string›, `threshold`: number, `payerNonce`: number): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:286](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L286)*
+*Defined in [apis/platform/api.ts:286](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L286)*
 
 Create an unsigned transaction to create a new Subnet. The unsigned transaction must be signed with the key of the account paying the transaction fee. The Subnet’s ID is the ID of the transaction that creates it (ie the response from issueTx when issuing the signed transaction).
 
@@ -295,7 +295,7 @@ ___
 
 ▸ **exportAVA**(`amount`: BN, `to`: string, `payerNonce`: number): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:355](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L355)*
+*Defined in [apis/platform/api.ts:355](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L355)*
 
 Send AVA from an account on the P-Chain to an address on the X-Chain. This transaction must be signed with the key of the account that the AVA is sent from and which pays the transaction fee. After issuing this transaction, you must call the X-Chain’s importAVA method to complete the transfer.
 
@@ -317,7 +317,7 @@ ___
 
 ▸ **getAccount**(`address`: string): *Promise‹object›*
 
-*Defined in [apis/platform/api.ts:99](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L99)*
+*Defined in [apis/platform/api.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L99)*
 
 The P-Chain uses an account model. An account is identified by an address. This method returns the account with the given address.
 
@@ -339,7 +339,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -351,7 +351,7 @@ ___
 
 ▸ **getBlockchainStatus**(`blockchainID`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:59](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L59)*
+*Defined in [apis/platform/api.ts:59](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L59)*
 
 Creates a new blockchain.
 
@@ -371,7 +371,7 @@ ___
 
 ▸ **getBlockchains**(): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:339](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L339)*
+*Defined in [apis/platform/api.ts:339](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L339)*
 
 Get all the blockchains that exist (excluding the P-Chain).
 
@@ -385,7 +385,7 @@ ___
 
 ▸ **getCurrentValidators**(`subnetID`: Buffer | string): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:134](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L134)*
+*Defined in [apis/platform/api.ts:134](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L134)*
 
 Lists the set of current validators.
 
@@ -407,7 +407,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -419,7 +419,7 @@ ___
 
 ▸ **getPendingValidators**(`subnetID`: Buffer | string): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:154](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L154)*
+*Defined in [apis/platform/api.ts:154](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L154)*
 
 Lists the set of pending validators.
 
@@ -441,7 +441,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -453,7 +453,7 @@ ___
 
 ▸ **getSubnets**(): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:433](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L433)*
+*Defined in [apis/platform/api.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L433)*
 
 Get all the subnets that exist.
 
@@ -467,7 +467,7 @@ ___
 
 ▸ **importAVA**(`username`: string, `password`: string, `to`: string, `payerNonce`: number): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:376](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L376)*
+*Defined in [apis/platform/api.ts:376](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L376)*
 
 Send AVA from an account on the P-Chain to an address on the X-Chain. This transaction must be signed with the key of the account that the AVA is sent from and which pays the transaction fee. After issuing this transaction, you must call the X-Chain’s importAVA method to complete the transfer.
 
@@ -490,7 +490,7 @@ ___
 
 ▸ **issueTx**(`tx`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:419](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L419)*
+*Defined in [apis/platform/api.ts:419](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L419)*
 
 Issue a transaction to the Platform Chain.
 
@@ -510,7 +510,7 @@ ___
 
 ▸ **listAccounts**(`username`: string, `password`: string): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:116](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L116)*
+*Defined in [apis/platform/api.ts:116](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L116)*
 
 List the accounts controlled by the user in the Keystore.
 
@@ -531,7 +531,7 @@ ___
 
 ▸ **sampleValidators**(`sampleSize`: number, `subnetID`: Buffer | string): *Promise‹Array‹string››*
 
-*Defined in [apis/platform/api.ts:175](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L175)*
+*Defined in [apis/platform/api.ts:175](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L175)*
 
 Samples `Size` validators from the current validator set.
 
@@ -554,7 +554,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 
@@ -572,7 +572,7 @@ ___
 
 ▸ **sign**(`username`: string, `password`: string, `tx`: string, `signer`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:400](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L400)*
+*Defined in [apis/platform/api.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L400)*
 
 Sign an unsigned or partially signed transaction.
 
@@ -597,7 +597,7 @@ ___
 
 ▸ **validatedBy**(`blockchainID`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:304](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L304)*
+*Defined in [apis/platform/api.ts:304](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L304)*
 
 Get the Subnet that validates a given blockchain.
 
@@ -617,7 +617,7 @@ ___
 
 ▸ **validates**(`subnetID`: Buffer | string): *Promise‹Array‹string››*
 
-*Defined in [apis/platform/api.ts:320](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/platform/api.ts#L320)*
+*Defined in [apis/platform/api.ts:320](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L320)*
 
 Get the IDs of the blockchains a Subnet validates.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_apis_platform_api_.platformapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_apis_platform_api_.platformapi.md
@@ -62,7 +62,7 @@ Class for interacting with a node's PlatformAPI
 
 *Overrides [JRPCAPI](_utils_types_.jrpcapi.md).[constructor](_utils_types_.jrpcapi.md#constructor)*
 
-*Defined in [apis/platform/api.ts:438](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L438)*
+*Defined in [apis/platform/api.ts:438](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L438)*
 
 This class should not be instantiated directly. Instead use the [Slopes.addAPI](_index_.slopes.md#addapi) method.
 
@@ -83,7 +83,7 @@ Name | Type | Default | Description |
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L33)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L32)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L34)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[jrpcVersion](_utils_types_.jrpcapi.md#protected-jrpcversion)*
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L80)*
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md).[rpcid](_utils_types_.jrpcapi.md#protected-rpcid)*
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **addDefaultSubnetDelegator**(`id`: string, `startTime`: Date, `endTime`: Date, `stakeAmount`: BN, `payerNonce`: number, `destination`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:263](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L263)*
+*Defined in [apis/platform/api.ts:263](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L263)*
 
 Add a delegator to the Default Subnet.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **addDefaultSubnetValidator**(`id`: string, `startTime`: Date, `endTime`: Date, `stakeAmount`: BN, `payerNonce`: number, `destination`: string, `delegationFeeRate`: BN): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:203](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L203)*
+*Defined in [apis/platform/api.ts:203](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L203)*
 
 Add a validator to the Default Subnet.
 
@@ -182,7 +182,7 @@ ___
 
 ▸ **addNonDefaultSubnetValidator**(`id`: string, `subnetID`: Buffer | string, `startTime`: Date, `endTime`: Date, `weight`: number, `payerNonce`: number): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:232](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L232)*
+*Defined in [apis/platform/api.ts:232](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L232)*
 
 Add a validator to a Subnet other than the Default Subnet. The validator must validate the Default Subnet for the entire duration they validate this Subnet.
 
@@ -209,7 +209,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **createAccount**(`username`: string, `password`: string, `privateKey`: Buffer | string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:77](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L77)*
+*Defined in [apis/platform/api.ts:77](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L77)*
 
 The P-Chain uses an account model. This method creates a P-Chain account on an existing user in the Keystore.
 
@@ -249,7 +249,7 @@ ___
 
 ▸ **createBlockchain**(`vmID`: string, `name`: string, `payerNonce`: number, `genesis`: string, `subnetID`: Buffer | string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:35](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L35)*
+*Defined in [apis/platform/api.ts:35](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L35)*
 
 Creates a new blockchain.
 
@@ -273,7 +273,7 @@ ___
 
 ▸ **createSubnet**(`controlKeys`: Array‹string›, `threshold`: number, `payerNonce`: number): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:286](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L286)*
+*Defined in [apis/platform/api.ts:286](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L286)*
 
 Create an unsigned transaction to create a new Subnet. The unsigned transaction must be signed with the key of the account paying the transaction fee. The Subnet’s ID is the ID of the transaction that creates it (ie the response from issueTx when issuing the signed transaction).
 
@@ -295,7 +295,7 @@ ___
 
 ▸ **exportAVA**(`amount`: BN, `to`: string, `payerNonce`: number): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:355](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L355)*
+*Defined in [apis/platform/api.ts:355](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L355)*
 
 Send AVA from an account on the P-Chain to an address on the X-Chain. This transaction must be signed with the key of the account that the AVA is sent from and which pays the transaction fee. After issuing this transaction, you must call the X-Chain’s importAVA method to complete the transfer.
 
@@ -317,7 +317,7 @@ ___
 
 ▸ **getAccount**(`address`: string): *Promise‹object›*
 
-*Defined in [apis/platform/api.ts:99](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L99)*
+*Defined in [apis/platform/api.ts:99](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L99)*
 
 The P-Chain uses an account model. An account is identified by an address. This method returns the account with the given address.
 
@@ -339,7 +339,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -351,7 +351,7 @@ ___
 
 ▸ **getBlockchainStatus**(`blockchainID`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:59](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L59)*
+*Defined in [apis/platform/api.ts:59](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L59)*
 
 Creates a new blockchain.
 
@@ -371,7 +371,7 @@ ___
 
 ▸ **getBlockchains**(): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:339](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L339)*
+*Defined in [apis/platform/api.ts:339](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L339)*
 
 Get all the blockchains that exist (excluding the P-Chain).
 
@@ -385,7 +385,7 @@ ___
 
 ▸ **getCurrentValidators**(`subnetID`: Buffer | string): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:134](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L134)*
+*Defined in [apis/platform/api.ts:134](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L134)*
 
 Lists the set of current validators.
 
@@ -407,7 +407,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -419,7 +419,7 @@ ___
 
 ▸ **getPendingValidators**(`subnetID`: Buffer | string): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:154](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L154)*
+*Defined in [apis/platform/api.ts:154](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L154)*
 
 Lists the set of pending validators.
 
@@ -441,7 +441,7 @@ ___
 
 *Inherited from [JRPCAPI](_utils_types_.jrpcapi.md)*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -453,7 +453,7 @@ ___
 
 ▸ **getSubnets**(): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L433)*
+*Defined in [apis/platform/api.ts:433](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L433)*
 
 Get all the subnets that exist.
 
@@ -467,7 +467,7 @@ ___
 
 ▸ **importAVA**(`username`: string, `password`: string, `to`: string, `payerNonce`: number): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:376](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L376)*
+*Defined in [apis/platform/api.ts:376](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L376)*
 
 Send AVA from an account on the P-Chain to an address on the X-Chain. This transaction must be signed with the key of the account that the AVA is sent from and which pays the transaction fee. After issuing this transaction, you must call the X-Chain’s importAVA method to complete the transfer.
 
@@ -490,7 +490,7 @@ ___
 
 ▸ **issueTx**(`tx`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:419](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L419)*
+*Defined in [apis/platform/api.ts:419](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L419)*
 
 Issue a transaction to the Platform Chain.
 
@@ -510,7 +510,7 @@ ___
 
 ▸ **listAccounts**(`username`: string, `password`: string): *Promise‹Array‹object››*
 
-*Defined in [apis/platform/api.ts:116](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L116)*
+*Defined in [apis/platform/api.ts:116](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L116)*
 
 List the accounts controlled by the user in the Keystore.
 
@@ -531,7 +531,7 @@ ___
 
 ▸ **sampleValidators**(`sampleSize`: number, `subnetID`: Buffer | string): *Promise‹Array‹string››*
 
-*Defined in [apis/platform/api.ts:175](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L175)*
+*Defined in [apis/platform/api.ts:175](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L175)*
 
 Samples `Size` validators from the current validator set.
 
@@ -554,7 +554,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 
@@ -572,7 +572,7 @@ ___
 
 ▸ **sign**(`username`: string, `password`: string, `tx`: string, `signer`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L400)*
+*Defined in [apis/platform/api.ts:400](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L400)*
 
 Sign an unsigned or partially signed transaction.
 
@@ -597,7 +597,7 @@ ___
 
 ▸ **validatedBy**(`blockchainID`: string): *Promise‹string›*
 
-*Defined in [apis/platform/api.ts:304](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L304)*
+*Defined in [apis/platform/api.ts:304](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L304)*
 
 Get the Subnet that validates a given blockchain.
 
@@ -617,7 +617,7 @@ ___
 
 ▸ **validates**(`subnetID`: Buffer | string): *Promise‹Array‹string››*
 
-*Defined in [apis/platform/api.ts:320](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/platform/api.ts#L320)*
+*Defined in [apis/platform/api.ts:320](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/platform/api.ts#L320)*
 
 Get the IDs of the blockchains a Subnet validates.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_index_.slopes.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_index_.slopes.md
@@ -59,7 +59,7 @@ let slopes = new Slopes("127.0.0.1", 9650, "https");
 
 *Overrides [SlopesCore](_slopes_.slopescore.md).[constructor](_slopes_.slopescore.md#constructor)*
 
-*Defined in [index.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L53)*
+*Defined in [index.ts:53](https://github.com/ava-labs/slopes/blob/ba50532/src/index.ts#L53)*
 
 Creates a new AVA instance. Sets the address and port of the main AVA Client.
 
@@ -84,7 +84,7 @@ Name | Type | Default | Description |
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[apis](_slopes_.slopescore.md#protected-apis)*
 
-*Defined in [slopes.ts:23](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L23)*
+*Defined in [slopes.ts:23](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L23)*
 
 #### Type declaration:
 
@@ -98,7 +98,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[ip](_slopes_.slopescore.md#protected-ip)*
 
-*Defined in [slopes.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L20)*
+*Defined in [slopes.ts:20](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L20)*
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[networkID](_slopes_.slopescore.md#protected-networkid)*
 
-*Defined in [slopes.ts:18](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L18)*
+*Defined in [slopes.ts:18](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L18)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[port](_slopes_.slopescore.md#protected-port)*
 
-*Defined in [slopes.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L21)*
+*Defined in [slopes.ts:21](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L21)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[protocol](_slopes_.slopescore.md#protected-protocol)*
 
-*Defined in [slopes.ts:19](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L19)*
+*Defined in [slopes.ts:19](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L19)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[url](_slopes_.slopescore.md#protected-url)*
 
-*Defined in [slopes.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L22)*
+*Defined in [slopes.ts:22](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L22)*
 
 ## Methods
 
@@ -146,7 +146,7 @@ ___
 
 ▸ **AVM**(): *[AVMAPI](_apis_avm_api_.avmapi.md)‹›*
 
-*Defined in [index.ts:37](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L37)*
+*Defined in [index.ts:37](https://github.com/ava-labs/slopes/blob/ba50532/src/index.ts#L37)*
 
 Returns a reference to the AVM RPC.
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **Admin**(): *[AdminAPI](_apis_admin_api_.adminapi.md)‹›*
 
-*Defined in [index.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L30)*
+*Defined in [index.ts:30](https://github.com/ava-labs/slopes/blob/ba50532/src/index.ts#L30)*
 
 Returns a reference to the Admin RPC.
 
@@ -170,7 +170,7 @@ ___
 
 ▸ **NodeKeys**(): *[KeystoreAPI](_apis_keystore_api_.keystoreapi.md)‹›*
 
-*Defined in [index.ts:51](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L51)*
+*Defined in [index.ts:51](https://github.com/ava-labs/slopes/blob/ba50532/src/index.ts#L51)*
 
 Returns a reference to the Keystore RPC for a node. We label it "NodeKeys" to reduce confusion about what it's accessing.
 
@@ -182,7 +182,7 @@ ___
 
 ▸ **Platform**(): *[PlatformAPI](_apis_platform_api_.platformapi.md)‹›*
 
-*Defined in [index.ts:44](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L44)*
+*Defined in [index.ts:44](https://github.com/ava-labs/slopes/blob/ba50532/src/index.ts#L44)*
 
 Returns a reference to the Platform RPC.
 
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:100](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L100)*
+*Defined in [slopes.ts:100](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L100)*
 
 Adds an API to the middleware. The API resolves to a registered blockchain's RPC.
 
@@ -235,7 +235,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:113](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L113)*
+*Defined in [slopes.ts:113](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L113)*
 
 Retrieves a reference to an API by its apiName label.
 
@@ -259,7 +259,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:174](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L174)*
+*Defined in [slopes.ts:174](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L174)*
 
 Makes a DELETE call to an API.
 
@@ -284,7 +284,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:159](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L159)*
+*Defined in [slopes.ts:159](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L159)*
 
 Makes a GET call to an API.
 
@@ -309,7 +309,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L49)*
+*Defined in [slopes.ts:49](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L49)*
 
 Returns the IP for the AVA node.
 
@@ -323,7 +323,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L70)*
+*Defined in [slopes.ts:70](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L70)*
 
 Returns the networkID;
 
@@ -337,7 +337,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:56](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L56)*
+*Defined in [slopes.ts:56](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L56)*
 
 Returns the port for the AVA node.
 
@@ -351,7 +351,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L42)*
+*Defined in [slopes.ts:42](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L42)*
 
 Returns the protocol such as "http", "https", "git", "ws", etc.
 
@@ -365,7 +365,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L63)*
+*Defined in [slopes.ts:63](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L63)*
 
 Returns the URL of the AVA node (ip + port);
 
@@ -379,7 +379,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:222](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L222)*
+*Defined in [slopes.ts:222](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L222)*
 
 Makes a PATCH call to an API.
 
@@ -405,7 +405,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:190](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L190)*
+*Defined in [slopes.ts:190](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L190)*
 
 Makes a POST call to an API.
 
@@ -431,7 +431,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:206](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L206)*
+*Defined in [slopes.ts:206](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L206)*
 
 Makes a PUT call to an API.
 
@@ -457,7 +457,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L32)*
+*Defined in [slopes.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L32)*
 
 Sets the address and port of the main AVA Client.
 
@@ -479,7 +479,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:77](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L77)*
+*Defined in [slopes.ts:77](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L77)*
 
 Sets the networkID
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_index_.slopes.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_index_.slopes.md
@@ -59,7 +59,7 @@ let slopes = new Slopes("127.0.0.1", 9650, "https");
 
 *Overrides [SlopesCore](_slopes_.slopescore.md).[constructor](_slopes_.slopescore.md#constructor)*
 
-*Defined in [index.ts:53](https://github.com/ava-labs/slopes/blob/2d2915d/src/index.ts#L53)*
+*Defined in [index.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L53)*
 
 Creates a new AVA instance. Sets the address and port of the main AVA Client.
 
@@ -84,7 +84,7 @@ Name | Type | Default | Description |
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[apis](_slopes_.slopescore.md#protected-apis)*
 
-*Defined in [slopes.ts:23](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L23)*
+*Defined in [slopes.ts:23](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L23)*
 
 #### Type declaration:
 
@@ -98,7 +98,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[ip](_slopes_.slopescore.md#protected-ip)*
 
-*Defined in [slopes.ts:20](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L20)*
+*Defined in [slopes.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L20)*
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[networkID](_slopes_.slopescore.md#protected-networkid)*
 
-*Defined in [slopes.ts:18](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L18)*
+*Defined in [slopes.ts:18](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L18)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[port](_slopes_.slopescore.md#protected-port)*
 
-*Defined in [slopes.ts:21](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L21)*
+*Defined in [slopes.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L21)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[protocol](_slopes_.slopescore.md#protected-protocol)*
 
-*Defined in [slopes.ts:19](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L19)*
+*Defined in [slopes.ts:19](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L19)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md).[url](_slopes_.slopescore.md#protected-url)*
 
-*Defined in [slopes.ts:22](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L22)*
+*Defined in [slopes.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L22)*
 
 ## Methods
 
@@ -146,7 +146,7 @@ ___
 
 ▸ **AVM**(): *[AVMAPI](_apis_avm_api_.avmapi.md)‹›*
 
-*Defined in [index.ts:37](https://github.com/ava-labs/slopes/blob/2d2915d/src/index.ts#L37)*
+*Defined in [index.ts:37](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L37)*
 
 Returns a reference to the AVM RPC.
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **Admin**(): *[AdminAPI](_apis_admin_api_.adminapi.md)‹›*
 
-*Defined in [index.ts:30](https://github.com/ava-labs/slopes/blob/2d2915d/src/index.ts#L30)*
+*Defined in [index.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L30)*
 
 Returns a reference to the Admin RPC.
 
@@ -170,7 +170,7 @@ ___
 
 ▸ **NodeKeys**(): *[KeystoreAPI](_apis_keystore_api_.keystoreapi.md)‹›*
 
-*Defined in [index.ts:51](https://github.com/ava-labs/slopes/blob/2d2915d/src/index.ts#L51)*
+*Defined in [index.ts:51](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L51)*
 
 Returns a reference to the Keystore RPC for a node. We label it "NodeKeys" to reduce confusion about what it's accessing.
 
@@ -182,7 +182,7 @@ ___
 
 ▸ **Platform**(): *[PlatformAPI](_apis_platform_api_.platformapi.md)‹›*
 
-*Defined in [index.ts:44](https://github.com/ava-labs/slopes/blob/2d2915d/src/index.ts#L44)*
+*Defined in [index.ts:44](https://github.com/ava-labs/slopes/blob/65cee65/src/index.ts#L44)*
 
 Returns a reference to the Platform RPC.
 
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:100](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L100)*
+*Defined in [slopes.ts:100](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L100)*
 
 Adds an API to the middleware. The API resolves to a registered blockchain's RPC.
 
@@ -235,7 +235,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:113](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L113)*
+*Defined in [slopes.ts:113](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L113)*
 
 Retrieves a reference to an API by its apiName label.
 
@@ -259,7 +259,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:174](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L174)*
+*Defined in [slopes.ts:174](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L174)*
 
 Makes a DELETE call to an API.
 
@@ -284,7 +284,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:159](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L159)*
+*Defined in [slopes.ts:159](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L159)*
 
 Makes a GET call to an API.
 
@@ -309,7 +309,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:49](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L49)*
+*Defined in [slopes.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L49)*
 
 Returns the IP for the AVA node.
 
@@ -323,7 +323,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:70](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L70)*
+*Defined in [slopes.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L70)*
 
 Returns the networkID;
 
@@ -337,7 +337,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:56](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L56)*
+*Defined in [slopes.ts:56](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L56)*
 
 Returns the port for the AVA node.
 
@@ -351,7 +351,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:42](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L42)*
+*Defined in [slopes.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L42)*
 
 Returns the protocol such as "http", "https", "git", "ws", etc.
 
@@ -365,7 +365,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:63](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L63)*
+*Defined in [slopes.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L63)*
 
 Returns the URL of the AVA node (ip + port);
 
@@ -379,7 +379,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:222](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L222)*
+*Defined in [slopes.ts:222](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L222)*
 
 Makes a PATCH call to an API.
 
@@ -405,7 +405,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:190](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L190)*
+*Defined in [slopes.ts:190](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L190)*
 
 Makes a POST call to an API.
 
@@ -431,7 +431,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:206](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L206)*
+*Defined in [slopes.ts:206](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L206)*
 
 Makes a PUT call to an API.
 
@@ -457,7 +457,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L32)*
+*Defined in [slopes.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L32)*
 
 Sets the address and port of the main AVA Client.
 
@@ -479,7 +479,7 @@ ___
 
 *Inherited from [SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:77](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L77)*
+*Defined in [slopes.ts:77](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L77)*
 
 Sets the networkID
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_slopes_.slopescore.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_slopes_.slopescore.md
@@ -53,7 +53,7 @@ let slopes = new SlopesCore("127.0.0.1", 9650, "https");
 
 \+ **new SlopesCore**(`ip`: string, `port`: number, `protocol`: string): *[SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:224](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L224)*
+*Defined in [slopes.ts:224](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L224)*
 
 Creates a new Slopes instance. Sets the address and port of the main AVA Client.
 
@@ -73,7 +73,7 @@ Name | Type | Default | Description |
 
 • **apis**: *object*
 
-*Defined in [slopes.ts:23](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L23)*
+*Defined in [slopes.ts:23](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L23)*
 
 #### Type declaration:
 
@@ -85,7 +85,7 @@ ___
 
 • **ip**: *string*
 
-*Defined in [slopes.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L20)*
+*Defined in [slopes.ts:20](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L20)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • **networkID**: *number* = 3
 
-*Defined in [slopes.ts:18](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L18)*
+*Defined in [slopes.ts:18](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L18)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 • **port**: *number*
 
-*Defined in [slopes.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L21)*
+*Defined in [slopes.ts:21](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L21)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 • **protocol**: *string*
 
-*Defined in [slopes.ts:19](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L19)*
+*Defined in [slopes.ts:19](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L19)*
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 • **url**: *string*
 
-*Defined in [slopes.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L22)*
+*Defined in [slopes.ts:22](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L22)*
 
 ## Methods
 
@@ -125,7 +125,7 @@ ___
 
 ▸ **addAPI**<**GA**>(`apiName`: string, `constructorFN`: object, `baseurl`: string, ...`args`: Array‹any›): *void*
 
-*Defined in [slopes.ts:100](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L100)*
+*Defined in [slopes.ts:100](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L100)*
 
 Adds an API to the middleware. The API resolves to a registered blockchain's RPC.
 
@@ -162,7 +162,7 @@ ___
 
 ▸ **api**<**GA**>(`apiName`: string): *GA*
 
-*Defined in [slopes.ts:113](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L113)*
+*Defined in [slopes.ts:113](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L113)*
 
 Retrieves a reference to an API by its apiName label.
 
@@ -184,7 +184,7 @@ ___
 
 ▸ **delete**(`baseurl`: string, `getdata`: object, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:174](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L174)*
+*Defined in [slopes.ts:174](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L174)*
 
 Makes a DELETE call to an API.
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **get**(`baseurl`: string, `getdata`: object, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:159](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L159)*
+*Defined in [slopes.ts:159](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L159)*
 
 Makes a GET call to an API.
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **getIP**(): *string*
 
-*Defined in [slopes.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L49)*
+*Defined in [slopes.ts:49](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L49)*
 
 Returns the IP for the AVA node.
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **getNetworkID**(): *number*
 
-*Defined in [slopes.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L70)*
+*Defined in [slopes.ts:70](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L70)*
 
 Returns the networkID;
 
@@ -254,7 +254,7 @@ ___
 
 ▸ **getPort**(): *number*
 
-*Defined in [slopes.ts:56](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L56)*
+*Defined in [slopes.ts:56](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L56)*
 
 Returns the port for the AVA node.
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **getProtocol**(): *string*
 
-*Defined in [slopes.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L42)*
+*Defined in [slopes.ts:42](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L42)*
 
 Returns the protocol such as "http", "https", "git", "ws", etc.
 
@@ -278,7 +278,7 @@ ___
 
 ▸ **getURL**(): *string*
 
-*Defined in [slopes.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L63)*
+*Defined in [slopes.ts:63](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L63)*
 
 Returns the URL of the AVA node (ip + port);
 
@@ -290,7 +290,7 @@ ___
 
 ▸ **patch**(`baseurl`: string, `getdata`: object, `postdata`: string | object | ArrayBuffer | ArrayBufferView, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:222](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L222)*
+*Defined in [slopes.ts:222](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L222)*
 
 Makes a PATCH call to an API.
 
@@ -314,7 +314,7 @@ ___
 
 ▸ **post**(`baseurl`: string, `getdata`: object, `postdata`: string | object | ArrayBuffer | ArrayBufferView, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:190](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L190)*
+*Defined in [slopes.ts:190](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L190)*
 
 Makes a POST call to an API.
 
@@ -338,7 +338,7 @@ ___
 
 ▸ **put**(`baseurl`: string, `getdata`: object, `postdata`: string | object | ArrayBuffer | ArrayBufferView, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:206](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L206)*
+*Defined in [slopes.ts:206](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L206)*
 
 Makes a PUT call to an API.
 
@@ -362,7 +362,7 @@ ___
 
 ▸ **setAddress**(`ip`: string, `port`: number, `protocol`: string): *void*
 
-*Defined in [slopes.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L32)*
+*Defined in [slopes.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L32)*
 
 Sets the address and port of the main AVA Client.
 
@@ -382,7 +382,7 @@ ___
 
 ▸ **setNetworkID**(`netid`: number): *void*
 
-*Defined in [slopes.ts:77](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L77)*
+*Defined in [slopes.ts:77](https://github.com/ava-labs/slopes/blob/ba50532/src/slopes.ts#L77)*
 
 Sets the networkID
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_slopes_.slopescore.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_slopes_.slopescore.md
@@ -53,7 +53,7 @@ let slopes = new SlopesCore("127.0.0.1", 9650, "https");
 
 \+ **new SlopesCore**(`ip`: string, `port`: number, `protocol`: string): *[SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [slopes.ts:224](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L224)*
+*Defined in [slopes.ts:224](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L224)*
 
 Creates a new Slopes instance. Sets the address and port of the main AVA Client.
 
@@ -73,7 +73,7 @@ Name | Type | Default | Description |
 
 • **apis**: *object*
 
-*Defined in [slopes.ts:23](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L23)*
+*Defined in [slopes.ts:23](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L23)*
 
 #### Type declaration:
 
@@ -85,7 +85,7 @@ ___
 
 • **ip**: *string*
 
-*Defined in [slopes.ts:20](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L20)*
+*Defined in [slopes.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L20)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • **networkID**: *number* = 3
 
-*Defined in [slopes.ts:18](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L18)*
+*Defined in [slopes.ts:18](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L18)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 • **port**: *number*
 
-*Defined in [slopes.ts:21](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L21)*
+*Defined in [slopes.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L21)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 • **protocol**: *string*
 
-*Defined in [slopes.ts:19](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L19)*
+*Defined in [slopes.ts:19](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L19)*
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 • **url**: *string*
 
-*Defined in [slopes.ts:22](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L22)*
+*Defined in [slopes.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L22)*
 
 ## Methods
 
@@ -125,7 +125,7 @@ ___
 
 ▸ **addAPI**<**GA**>(`apiName`: string, `constructorFN`: object, `baseurl`: string, ...`args`: Array‹any›): *void*
 
-*Defined in [slopes.ts:100](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L100)*
+*Defined in [slopes.ts:100](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L100)*
 
 Adds an API to the middleware. The API resolves to a registered blockchain's RPC.
 
@@ -162,7 +162,7 @@ ___
 
 ▸ **api**<**GA**>(`apiName`: string): *GA*
 
-*Defined in [slopes.ts:113](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L113)*
+*Defined in [slopes.ts:113](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L113)*
 
 Retrieves a reference to an API by its apiName label.
 
@@ -184,7 +184,7 @@ ___
 
 ▸ **delete**(`baseurl`: string, `getdata`: object, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:174](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L174)*
+*Defined in [slopes.ts:174](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L174)*
 
 Makes a DELETE call to an API.
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **get**(`baseurl`: string, `getdata`: object, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:159](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L159)*
+*Defined in [slopes.ts:159](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L159)*
 
 Makes a GET call to an API.
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **getIP**(): *string*
 
-*Defined in [slopes.ts:49](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L49)*
+*Defined in [slopes.ts:49](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L49)*
 
 Returns the IP for the AVA node.
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **getNetworkID**(): *number*
 
-*Defined in [slopes.ts:70](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L70)*
+*Defined in [slopes.ts:70](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L70)*
 
 Returns the networkID;
 
@@ -254,7 +254,7 @@ ___
 
 ▸ **getPort**(): *number*
 
-*Defined in [slopes.ts:56](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L56)*
+*Defined in [slopes.ts:56](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L56)*
 
 Returns the port for the AVA node.
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **getProtocol**(): *string*
 
-*Defined in [slopes.ts:42](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L42)*
+*Defined in [slopes.ts:42](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L42)*
 
 Returns the protocol such as "http", "https", "git", "ws", etc.
 
@@ -278,7 +278,7 @@ ___
 
 ▸ **getURL**(): *string*
 
-*Defined in [slopes.ts:63](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L63)*
+*Defined in [slopes.ts:63](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L63)*
 
 Returns the URL of the AVA node (ip + port);
 
@@ -290,7 +290,7 @@ ___
 
 ▸ **patch**(`baseurl`: string, `getdata`: object, `postdata`: string | object | ArrayBuffer | ArrayBufferView, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:222](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L222)*
+*Defined in [slopes.ts:222](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L222)*
 
 Makes a PATCH call to an API.
 
@@ -314,7 +314,7 @@ ___
 
 ▸ **post**(`baseurl`: string, `getdata`: object, `postdata`: string | object | ArrayBuffer | ArrayBufferView, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:190](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L190)*
+*Defined in [slopes.ts:190](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L190)*
 
 Makes a POST call to an API.
 
@@ -338,7 +338,7 @@ ___
 
 ▸ **put**(`baseurl`: string, `getdata`: object, `postdata`: string | object | ArrayBuffer | ArrayBufferView, `headers`: object, `axiosConfig`: AxiosRequestConfig): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [slopes.ts:206](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L206)*
+*Defined in [slopes.ts:206](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L206)*
 
 Makes a PUT call to an API.
 
@@ -362,7 +362,7 @@ ___
 
 ▸ **setAddress**(`ip`: string, `port`: number, `protocol`: string): *void*
 
-*Defined in [slopes.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L32)*
+*Defined in [slopes.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L32)*
 
 Sets the address and port of the main AVA Client.
 
@@ -382,7 +382,7 @@ ___
 
 ▸ **setNetworkID**(`netid`: number): *void*
 
-*Defined in [slopes.ts:77](https://github.com/ava-labs/slopes/blob/2d2915d/src/slopes.ts#L77)*
+*Defined in [slopes.ts:77](https://github.com/ava-labs/slopes/blob/65cee65/src/slopes.ts#L77)*
 
 Sets the networkID
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_bintools_.base58.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_bintools_.base58.md
@@ -35,7 +35,7 @@ let buff:Buffer = b58.decode(somestring);
 
 • **alphabetIdx0**: *string* = "1"
 
-*Defined in [utils/bintools.ts:234](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L234)*
+*Defined in [utils/bintools.ts:234](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L234)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
         255, 255, 255, 255, 255, 255, 255, 255
     ]
 
-*Defined in [utils/bintools.ts:235](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L235)*
+*Defined in [utils/bintools.ts:235](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L235)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • **b58alphabet**: *string* = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
-*Defined in [utils/bintools.ts:233](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L233)*
+*Defined in [utils/bintools.ts:233](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L233)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 • **big58Radix**: *BN* =  new BN(58)
 
-*Defined in [utils/bintools.ts:269](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L269)*
+*Defined in [utils/bintools.ts:269](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L269)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 • **bigZero**: *BN* =  new BN(0)
 
-*Defined in [utils/bintools.ts:270](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L270)*
+*Defined in [utils/bintools.ts:270](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L270)*
 
 ## Methods
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **decode**(`b`: string): *Buffer*
 
-*Defined in [utils/bintools.ts:304](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L304)*
+*Defined in [utils/bintools.ts:304](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L304)*
 
 Dencodes a base-58 into a [Buffer](https://github.com/feross/buffer)
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **encode**(`buff`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:279](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L279)*
+*Defined in [utils/bintools.ts:279](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L279)*
 
 Encodes a [Buffer](https://github.com/feross/buffer) as a base-58 string
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_bintools_.base58.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_bintools_.base58.md
@@ -35,7 +35,7 @@ let buff:Buffer = b58.decode(somestring);
 
 • **alphabetIdx0**: *string* = "1"
 
-*Defined in [utils/bintools.ts:234](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L234)*
+*Defined in [utils/bintools.ts:234](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L234)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
         255, 255, 255, 255, 255, 255, 255, 255
     ]
 
-*Defined in [utils/bintools.ts:235](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L235)*
+*Defined in [utils/bintools.ts:235](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L235)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • **b58alphabet**: *string* = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
-*Defined in [utils/bintools.ts:233](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L233)*
+*Defined in [utils/bintools.ts:233](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L233)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 • **big58Radix**: *BN* =  new BN(58)
 
-*Defined in [utils/bintools.ts:269](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L269)*
+*Defined in [utils/bintools.ts:269](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L269)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 • **bigZero**: *BN* =  new BN(0)
 
-*Defined in [utils/bintools.ts:270](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L270)*
+*Defined in [utils/bintools.ts:270](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L270)*
 
 ## Methods
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **decode**(`b`: string): *Buffer*
 
-*Defined in [utils/bintools.ts:304](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L304)*
+*Defined in [utils/bintools.ts:304](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L304)*
 
 Dencodes a base-58 into a [Buffer](https://github.com/feross/buffer)
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **encode**(`buff`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:279](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L279)*
+*Defined in [utils/bintools.ts:279](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L279)*
 
 Encodes a [Buffer](https://github.com/feross/buffer) as a base-58 string
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_bintools_.bintools.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_bintools_.bintools.md
@@ -55,7 +55,7 @@ let b58str = bintools.bufferToB58(Buffer.from("Wubalubadubdub!"));
 
 \+ **new BinTools**(): *[BinTools](_utils_bintools_.bintools.md)*
 
-*Defined in [utils/bintools.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L22)*
+*Defined in [utils/bintools.ts:22](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L22)*
 
 **Returns:** *[BinTools](_utils_bintools_.bintools.md)*
 
@@ -65,7 +65,7 @@ let b58str = bintools.bufferToB58(Buffer.from("Wubalubadubdub!"));
 
 • **b58**: *[Base58](_utils_bintools_.base58.md)*
 
-*Defined in [utils/bintools.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L26)*
+*Defined in [utils/bintools.ts:26](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L26)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 ▪ **instance**: *[BinTools](_utils_bintools_.bintools.md)*
 
-*Defined in [utils/bintools.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L22)*
+*Defined in [utils/bintools.ts:22](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L22)*
 
 ## Methods
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **addChecksum**(`buff`: Buffer): *Buffer*
 
-*Defined in [utils/bintools.ts:151](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L151)*
+*Defined in [utils/bintools.ts:151](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L151)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and adds a checksum, returning a [Buffer](https://github.com/feross/buffer) with the 4-byte checksum appended.
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **addressToString**(`chainid`: string, `bytes`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:194](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L194)*
+*Defined in [utils/bintools.ts:194](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L194)*
 
 **Parameters:**
 
@@ -116,7 +116,7 @@ ___
 
 ▸ **avaDeserialize**(`bytes`: Buffer | string): *Buffer*
 
-*Defined in [utils/bintools.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L184)*
+*Defined in [utils/bintools.ts:184](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L184)*
 
 Takes an AVA serialized [Buffer](https://github.com/feross/buffer) or base-58 string and returns a [Buffer](https://github.com/feross/buffer) of the original data. Throws on error.
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **avaSerialize**(`bytes`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:174](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L174)*
+*Defined in [utils/bintools.ts:174](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L174)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and returns a base-58 string with checksum as per the AVA standard.
 
@@ -154,7 +154,7 @@ ___
 
 ▸ **b58ToBuffer**(`b58str`: string): *Buffer*
 
-*Defined in [utils/bintools.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L89)*
+*Defined in [utils/bintools.ts:89](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L89)*
 
 Takes a base-58 string and returns a [Buffer](https://github.com/feross/buffer).
 
@@ -172,7 +172,7 @@ ___
 
 ▸ **bufferToB58**(`buff`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L80)*
+*Defined in [utils/bintools.ts:80](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L80)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and returns a base-58 string of the [Buffer](https://github.com/feross/buffer).
 
@@ -190,7 +190,7 @@ ___
 
 ▸ **bufferToString**(`buff`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:44](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L44)*
+*Defined in [utils/bintools.ts:44](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L44)*
 
 Produces a string from a [Buffer](https://github.com/feross/buffer) representing a string.
 
@@ -208,7 +208,7 @@ ___
 
 ▸ **copyFrom**(`buff`: Buffer, `start`: number, `end`: number): *Buffer*
 
-*Defined in [utils/bintools.ts:67](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L67)*
+*Defined in [utils/bintools.ts:67](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L67)*
 
 Makes a copy (no reference) of a [Buffer](https://github.com/feross/buffer) over provided indecies.
 
@@ -228,7 +228,7 @@ ___
 
 ▸ **fromArrayBufferToBuffer**(`ab`: ArrayBuffer): *Buffer*
 
-*Defined in [utils/bintools.ts:112](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L112)*
+*Defined in [utils/bintools.ts:112](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L112)*
 
 Takes an ArrayBuffer and converts it to a [Buffer](https://github.com/feross/buffer).
 
@@ -246,7 +246,7 @@ ___
 
 ▸ **fromBNToBuffer**(`bn`: BN, `length?`: number): *Buffer*
 
-*Defined in [utils/bintools.ts:135](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L135)*
+*Defined in [utils/bintools.ts:135](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L135)*
 
 Takes a [BN](https://github.com/indutny/bn.js/) and converts it to a [Buffer](https://github.com/feross/buffer).
 
@@ -265,7 +265,7 @@ ___
 
 ▸ **fromBufferToArrayBuffer**(`buff`: Buffer): *ArrayBuffer*
 
-*Defined in [utils/bintools.ts:98](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L98)*
+*Defined in [utils/bintools.ts:98](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L98)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and returns an ArrayBuffer.
 
@@ -283,7 +283,7 @@ ___
 
 ▸ **fromBufferToBN**(`buff`: Buffer): *BN*
 
-*Defined in [utils/bintools.ts:125](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L125)*
+*Defined in [utils/bintools.ts:125](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L125)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and converts it to a [BN](https://github.com/indutny/bn.js/).
 
@@ -301,7 +301,7 @@ ___
 
 ▸ **parseAddress**(`addr`: string, `blockchainID`: string, `alias`: string, `addrlen`: number): *Buffer*
 
-*Defined in [utils/bintools.ts:208](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L208)*
+*Defined in [utils/bintools.ts:208](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L208)*
 
 Takes an address and returns its [Buffer](https://github.com/feross/buffer) representation if valid.
 
@@ -324,7 +324,7 @@ ___
 
 ▸ **stringToAddress**(`address`: string): *Buffer*
 
-*Defined in [utils/bintools.ts:198](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L198)*
+*Defined in [utils/bintools.ts:198](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L198)*
 
 **Parameters:**
 
@@ -340,7 +340,7 @@ ___
 
 ▸ **stringToBuffer**(`str`: string): *Buffer*
 
-*Defined in [utils/bintools.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L53)*
+*Defined in [utils/bintools.ts:53](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L53)*
 
 Produces a [Buffer](https://github.com/feross/buffer) from a string.
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **validateChecksum**(`buff`: Buffer): *boolean*
 
-*Defined in [utils/bintools.ts:161](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L161)*
+*Defined in [utils/bintools.ts:161](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L161)*
 
 Takes a [Buffer](https://github.com/feross/buffer) with an appended 4-byte checksum and returns true if the checksum is valid, otherwise false.
 
@@ -376,7 +376,7 @@ ___
 
 ▸ **getInstance**(): *[BinTools](_utils_bintools_.bintools.md)*
 
-*Defined in [utils/bintools.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L32)*
+*Defined in [utils/bintools.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/bintools.ts#L32)*
 
 Retrieves the BinTools singleton.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_bintools_.bintools.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_bintools_.bintools.md
@@ -55,7 +55,7 @@ let b58str = bintools.bufferToB58(Buffer.from("Wubalubadubdub!"));
 
 \+ **new BinTools**(): *[BinTools](_utils_bintools_.bintools.md)*
 
-*Defined in [utils/bintools.ts:22](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L22)*
+*Defined in [utils/bintools.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L22)*
 
 **Returns:** *[BinTools](_utils_bintools_.bintools.md)*
 
@@ -65,7 +65,7 @@ let b58str = bintools.bufferToB58(Buffer.from("Wubalubadubdub!"));
 
 • **b58**: *[Base58](_utils_bintools_.base58.md)*
 
-*Defined in [utils/bintools.ts:26](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L26)*
+*Defined in [utils/bintools.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L26)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 ▪ **instance**: *[BinTools](_utils_bintools_.bintools.md)*
 
-*Defined in [utils/bintools.ts:22](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L22)*
+*Defined in [utils/bintools.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L22)*
 
 ## Methods
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **addChecksum**(`buff`: Buffer): *Buffer*
 
-*Defined in [utils/bintools.ts:151](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L151)*
+*Defined in [utils/bintools.ts:151](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L151)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and adds a checksum, returning a [Buffer](https://github.com/feross/buffer) with the 4-byte checksum appended.
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **addressToString**(`chainid`: string, `bytes`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:194](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L194)*
+*Defined in [utils/bintools.ts:194](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L194)*
 
 **Parameters:**
 
@@ -116,7 +116,7 @@ ___
 
 ▸ **avaDeserialize**(`bytes`: Buffer | string): *Buffer*
 
-*Defined in [utils/bintools.ts:184](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L184)*
+*Defined in [utils/bintools.ts:184](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L184)*
 
 Takes an AVA serialized [Buffer](https://github.com/feross/buffer) or base-58 string and returns a [Buffer](https://github.com/feross/buffer) of the original data. Throws on error.
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **avaSerialize**(`bytes`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:174](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L174)*
+*Defined in [utils/bintools.ts:174](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L174)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and returns a base-58 string with checksum as per the AVA standard.
 
@@ -154,7 +154,7 @@ ___
 
 ▸ **b58ToBuffer**(`b58str`: string): *Buffer*
 
-*Defined in [utils/bintools.ts:89](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L89)*
+*Defined in [utils/bintools.ts:89](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L89)*
 
 Takes a base-58 string and returns a [Buffer](https://github.com/feross/buffer).
 
@@ -172,7 +172,7 @@ ___
 
 ▸ **bufferToB58**(`buff`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:80](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L80)*
+*Defined in [utils/bintools.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L80)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and returns a base-58 string of the [Buffer](https://github.com/feross/buffer).
 
@@ -190,7 +190,7 @@ ___
 
 ▸ **bufferToString**(`buff`: Buffer): *string*
 
-*Defined in [utils/bintools.ts:44](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L44)*
+*Defined in [utils/bintools.ts:44](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L44)*
 
 Produces a string from a [Buffer](https://github.com/feross/buffer) representing a string.
 
@@ -208,7 +208,7 @@ ___
 
 ▸ **copyFrom**(`buff`: Buffer, `start`: number, `end`: number): *Buffer*
 
-*Defined in [utils/bintools.ts:67](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L67)*
+*Defined in [utils/bintools.ts:67](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L67)*
 
 Makes a copy (no reference) of a [Buffer](https://github.com/feross/buffer) over provided indecies.
 
@@ -228,7 +228,7 @@ ___
 
 ▸ **fromArrayBufferToBuffer**(`ab`: ArrayBuffer): *Buffer*
 
-*Defined in [utils/bintools.ts:112](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L112)*
+*Defined in [utils/bintools.ts:112](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L112)*
 
 Takes an ArrayBuffer and converts it to a [Buffer](https://github.com/feross/buffer).
 
@@ -246,7 +246,7 @@ ___
 
 ▸ **fromBNToBuffer**(`bn`: BN, `length?`: number): *Buffer*
 
-*Defined in [utils/bintools.ts:135](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L135)*
+*Defined in [utils/bintools.ts:135](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L135)*
 
 Takes a [BN](https://github.com/indutny/bn.js/) and converts it to a [Buffer](https://github.com/feross/buffer).
 
@@ -265,7 +265,7 @@ ___
 
 ▸ **fromBufferToArrayBuffer**(`buff`: Buffer): *ArrayBuffer*
 
-*Defined in [utils/bintools.ts:98](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L98)*
+*Defined in [utils/bintools.ts:98](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L98)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and returns an ArrayBuffer.
 
@@ -283,7 +283,7 @@ ___
 
 ▸ **fromBufferToBN**(`buff`: Buffer): *BN*
 
-*Defined in [utils/bintools.ts:125](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L125)*
+*Defined in [utils/bintools.ts:125](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L125)*
 
 Takes a [Buffer](https://github.com/feross/buffer) and converts it to a [BN](https://github.com/indutny/bn.js/).
 
@@ -301,7 +301,7 @@ ___
 
 ▸ **parseAddress**(`addr`: string, `blockchainID`: string, `alias`: string, `addrlen`: number): *Buffer*
 
-*Defined in [utils/bintools.ts:208](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L208)*
+*Defined in [utils/bintools.ts:208](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L208)*
 
 Takes an address and returns its [Buffer](https://github.com/feross/buffer) representation if valid.
 
@@ -324,7 +324,7 @@ ___
 
 ▸ **stringToAddress**(`address`: string): *Buffer*
 
-*Defined in [utils/bintools.ts:198](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L198)*
+*Defined in [utils/bintools.ts:198](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L198)*
 
 **Parameters:**
 
@@ -340,7 +340,7 @@ ___
 
 ▸ **stringToBuffer**(`str`: string): *Buffer*
 
-*Defined in [utils/bintools.ts:53](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L53)*
+*Defined in [utils/bintools.ts:53](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L53)*
 
 Produces a [Buffer](https://github.com/feross/buffer) from a string.
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **validateChecksum**(`buff`: Buffer): *boolean*
 
-*Defined in [utils/bintools.ts:161](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L161)*
+*Defined in [utils/bintools.ts:161](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L161)*
 
 Takes a [Buffer](https://github.com/feross/buffer) with an appended 4-byte checksum and returns true if the checksum is valid, otherwise false.
 
@@ -376,7 +376,7 @@ ___
 
 ▸ **getInstance**(): *[BinTools](_utils_bintools_.bintools.md)*
 
-*Defined in [utils/bintools.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/bintools.ts#L32)*
+*Defined in [utils/bintools.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/bintools.ts#L32)*
 
 Retrieves the BinTools singleton.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_crypto_.cryptohelpers.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_crypto_.cryptohelpers.md
@@ -40,7 +40,7 @@ Encryption is using XChaCha20Poly1305 with a random public nonce.
 
 \+ **new CryptoHelpers**(): *[CryptoHelpers](_utils_crypto_.cryptohelpers.md)*
 
-*Defined in [utils/crypto.ts:176](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L176)*
+*Defined in [utils/crypto.ts:176](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L176)*
 
 **Returns:** *[CryptoHelpers](_utils_crypto_.cryptohelpers.md)*
 
@@ -50,7 +50,7 @@ Encryption is using XChaCha20Poly1305 with a random public nonce.
 
 • **libsodium**: *"/Users/carloscardona/Sites/AVALabs/slopes/node_modules/@types/libsodium-wrappers/index"*
 
-*Defined in [utils/crypto.ts:16](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L16)*
+*Defined in [utils/crypto.ts:16](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L16)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • **memlimit**: *number* = 524288000
 
-*Defined in [utils/crypto.ts:14](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L14)*
+*Defined in [utils/crypto.ts:14](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L14)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • **opslimit**: *number* = 3
 
-*Defined in [utils/crypto.ts:15](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L15)*
+*Defined in [utils/crypto.ts:15](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L15)*
 
 ## Methods
 
@@ -74,7 +74,7 @@ ___
 
 ▸ **_pwcleaner**(`password`: string, `salt`: Uint8Array): *Promise‹Uint8Array›*
 
-*Defined in [utils/crypto.ts:67](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L67)*
+*Defined in [utils/crypto.ts:67](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L67)*
 
 Internal-intended function for cleaning passwords.
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **decrypt**(`password`: string, `ciphertext`: Buffer, `salt`: Buffer, `nonce`: Buffer): *Promise‹Buffer›*
 
-*Defined in [utils/crypto.ts:171](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L171)*
+*Defined in [utils/crypto.ts:171](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L171)*
 
 Decrypts ciphertext with the provided password, nonce, ans salt.
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **encrypt**(`password`: string, `plaintext`: Buffer | string, `salt`: Buffer): *Promise‹object›*
 
-*Defined in [utils/crypto.ts:136](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L136)*
+*Defined in [utils/crypto.ts:136](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L136)*
 
 Encrypts plaintext with the provided password using XChaCha20Poly1305.
 
@@ -136,7 +136,7 @@ ___
 
 ▸ **getMemoryLimit**(): *number*
 
-*Defined in [utils/crypto.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L21)*
+*Defined in [utils/crypto.ts:21](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L21)*
 
 Retrieves the memory limit that can be spent generating password-safe hashes.
 
@@ -148,7 +148,7 @@ ___
 
 ▸ **getOpsLimit**(): *number*
 
-*Defined in [utils/crypto.ts:37](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L37)*
+*Defined in [utils/crypto.ts:37](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L37)*
 
 Retrieves the cpu limit that can be spent generating password-safe hashes.
 
@@ -160,7 +160,7 @@ ___
 
 ▸ **makeSalt**(): *Promise‹Buffer›*
 
-*Defined in [utils/crypto.ts:101](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L101)*
+*Defined in [utils/crypto.ts:101](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L101)*
 
 Generates a randomized [Buffer](https://github.com/feross/buffer) to be used as a salt
 
@@ -172,7 +172,7 @@ ___
 
 ▸ **pwhash**(`password`: string, `salt`: Buffer): *Promise‹object›*
 
-*Defined in [utils/crypto.ts:114](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L114)*
+*Defined in [utils/crypto.ts:114](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L114)*
 
 Produces a password-safe hash.
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **setMemoryLimit**(`memlimit`: number): *void*
 
-*Defined in [utils/crypto.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L30)*
+*Defined in [utils/crypto.ts:30](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L30)*
 
 Sets the memory limit that can be spent generating password-safe hashes.
 
@@ -211,7 +211,7 @@ ___
 
 ▸ **setOpsLimit**(`opslimit`: number): *void*
 
-*Defined in [utils/crypto.ts:46](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L46)*
+*Defined in [utils/crypto.ts:46](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L46)*
 
 Retrieves the cpu limit that can be spent generating password-safe hashes.
 
@@ -229,7 +229,7 @@ ___
 
 ▸ **sha256**(`message`: string | Buffer | Uint8Array): *Buffer*
 
-*Defined in [utils/crypto.ts:88](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L88)*
+*Defined in [utils/crypto.ts:88](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/crypto.ts#L88)*
 
 A SHA256 helper function.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_crypto_.cryptohelpers.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_crypto_.cryptohelpers.md
@@ -40,7 +40,7 @@ Encryption is using XChaCha20Poly1305 with a random public nonce.
 
 \+ **new CryptoHelpers**(): *[CryptoHelpers](_utils_crypto_.cryptohelpers.md)*
 
-*Defined in [utils/crypto.ts:176](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L176)*
+*Defined in [utils/crypto.ts:176](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L176)*
 
 **Returns:** *[CryptoHelpers](_utils_crypto_.cryptohelpers.md)*
 
@@ -50,7 +50,7 @@ Encryption is using XChaCha20Poly1305 with a random public nonce.
 
 • **libsodium**: *"/Users/carloscardona/Sites/AVALabs/slopes/node_modules/@types/libsodium-wrappers/index"*
 
-*Defined in [utils/crypto.ts:16](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L16)*
+*Defined in [utils/crypto.ts:16](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L16)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • **memlimit**: *number* = 524288000
 
-*Defined in [utils/crypto.ts:14](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L14)*
+*Defined in [utils/crypto.ts:14](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L14)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • **opslimit**: *number* = 3
 
-*Defined in [utils/crypto.ts:15](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L15)*
+*Defined in [utils/crypto.ts:15](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L15)*
 
 ## Methods
 
@@ -74,7 +74,7 @@ ___
 
 ▸ **_pwcleaner**(`password`: string, `salt`: Uint8Array): *Promise‹Uint8Array›*
 
-*Defined in [utils/crypto.ts:67](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L67)*
+*Defined in [utils/crypto.ts:67](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L67)*
 
 Internal-intended function for cleaning passwords.
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **decrypt**(`password`: string, `ciphertext`: Buffer, `salt`: Buffer, `nonce`: Buffer): *Promise‹Buffer›*
 
-*Defined in [utils/crypto.ts:171](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L171)*
+*Defined in [utils/crypto.ts:171](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L171)*
 
 Decrypts ciphertext with the provided password, nonce, ans salt.
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **encrypt**(`password`: string, `plaintext`: Buffer | string, `salt`: Buffer): *Promise‹object›*
 
-*Defined in [utils/crypto.ts:136](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L136)*
+*Defined in [utils/crypto.ts:136](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L136)*
 
 Encrypts plaintext with the provided password using XChaCha20Poly1305.
 
@@ -136,7 +136,7 @@ ___
 
 ▸ **getMemoryLimit**(): *number*
 
-*Defined in [utils/crypto.ts:21](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L21)*
+*Defined in [utils/crypto.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L21)*
 
 Retrieves the memory limit that can be spent generating password-safe hashes.
 
@@ -148,7 +148,7 @@ ___
 
 ▸ **getOpsLimit**(): *number*
 
-*Defined in [utils/crypto.ts:37](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L37)*
+*Defined in [utils/crypto.ts:37](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L37)*
 
 Retrieves the cpu limit that can be spent generating password-safe hashes.
 
@@ -160,7 +160,7 @@ ___
 
 ▸ **makeSalt**(): *Promise‹Buffer›*
 
-*Defined in [utils/crypto.ts:101](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L101)*
+*Defined in [utils/crypto.ts:101](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L101)*
 
 Generates a randomized [Buffer](https://github.com/feross/buffer) to be used as a salt
 
@@ -172,7 +172,7 @@ ___
 
 ▸ **pwhash**(`password`: string, `salt`: Buffer): *Promise‹object›*
 
-*Defined in [utils/crypto.ts:114](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L114)*
+*Defined in [utils/crypto.ts:114](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L114)*
 
 Produces a password-safe hash.
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **setMemoryLimit**(`memlimit`: number): *void*
 
-*Defined in [utils/crypto.ts:30](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L30)*
+*Defined in [utils/crypto.ts:30](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L30)*
 
 Sets the memory limit that can be spent generating password-safe hashes.
 
@@ -211,7 +211,7 @@ ___
 
 ▸ **setOpsLimit**(`opslimit`: number): *void*
 
-*Defined in [utils/crypto.ts:46](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L46)*
+*Defined in [utils/crypto.ts:46](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L46)*
 
 Retrieves the cpu limit that can be spent generating password-safe hashes.
 
@@ -229,7 +229,7 @@ ___
 
 ▸ **sha256**(`message`: string | Buffer | Uint8Array): *Buffer*
 
-*Defined in [utils/crypto.ts:88](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/crypto.ts#L88)*
+*Defined in [utils/crypto.ts:88](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/crypto.ts#L88)*
 
 A SHA256 helper function.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_db_.db.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_db_.db.md
@@ -38,7 +38,7 @@ const blockchaindb = db.getNamespace("mychain");
 
 \+ **new DB**(): *[DB](_utils_db_.db.md)*
 
-*Defined in [utils/db.ts:20](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/db.ts#L20)*
+*Defined in [utils/db.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L20)*
 
 **Returns:** *[DB](_utils_db_.db.md)*
 
@@ -48,7 +48,7 @@ const blockchaindb = db.getNamespace("mychain");
 
 ▪ **instance**: *[DB](_utils_db_.db.md)*
 
-*Defined in [utils/db.ts:19](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/db.ts#L19)*
+*Defined in [utils/db.ts:19](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 ▪ **store**: *store* =  store
 
-*Defined in [utils/db.ts:20](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/db.ts#L20)*
+*Defined in [utils/db.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L20)*
 
 ## Methods
 
@@ -64,7 +64,7 @@ ___
 
 ▸ **getInstance**(): *[DB](_utils_db_.db.md)*
 
-*Defined in [utils/db.ts:26](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/db.ts#L26)*
+*Defined in [utils/db.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L26)*
 
 Retrieves the database singleton.
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **getNamespace**(`ns`: string): *StoreAPI*
 
-*Defined in [utils/db.ts:38](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/db.ts#L38)*
+*Defined in [utils/db.ts:38](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L38)*
 
 Gets a namespace from the database singleton.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_db_.db.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_db_.db.md
@@ -38,7 +38,7 @@ const blockchaindb = db.getNamespace("mychain");
 
 \+ **new DB**(): *[DB](_utils_db_.db.md)*
 
-*Defined in [utils/db.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L20)*
+*Defined in [utils/db.ts:20](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/db.ts#L20)*
 
 **Returns:** *[DB](_utils_db_.db.md)*
 
@@ -48,7 +48,7 @@ const blockchaindb = db.getNamespace("mychain");
 
 ▪ **instance**: *[DB](_utils_db_.db.md)*
 
-*Defined in [utils/db.ts:19](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L19)*
+*Defined in [utils/db.ts:19](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/db.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 ▪ **store**: *store* =  store
 
-*Defined in [utils/db.ts:20](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L20)*
+*Defined in [utils/db.ts:20](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/db.ts#L20)*
 
 ## Methods
 
@@ -64,7 +64,7 @@ ___
 
 ▸ **getInstance**(): *[DB](_utils_db_.db.md)*
 
-*Defined in [utils/db.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L26)*
+*Defined in [utils/db.ts:26](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/db.ts#L26)*
 
 Retrieves the database singleton.
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **getNamespace**(`ns`: string): *StoreAPI*
 
-*Defined in [utils/db.ts:38](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/db.ts#L38)*
+*Defined in [utils/db.ts:38](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/db.ts#L38)*
 
 Gets a namespace from the database singleton.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.apibase.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.apibase.md
@@ -34,7 +34,7 @@ Abstract class defining a generic endpoint that all endpoints must implement (ex
 
 \+ **new APIBase**(`core`: [SlopesCore](_slopes_.slopescore.md), `baseurl`: string): *[APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:66](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L66)*
+*Defined in [utils/types.ts:66](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L66)*
 
 **Parameters:**
 
@@ -51,7 +51,7 @@ Name | Type | Description |
 
 • **baseurl**: *string*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **core**: *[SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 • **db**: *StoreAPI*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
 
 ## Methods
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **getBaseURL**(): *string*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -87,7 +87,7 @@ ___
 
 ▸ **getDB**(): *StoreAPI*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **setBaseURL**(`baseurl`: string): *void*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.apibase.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.apibase.md
@@ -34,7 +34,7 @@ Abstract class defining a generic endpoint that all endpoints must implement (ex
 
 \+ **new APIBase**(`core`: [SlopesCore](_slopes_.slopescore.md), `baseurl`: string): *[APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:66](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L66)*
+*Defined in [utils/types.ts:66](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L66)*
 
 **Parameters:**
 
@@ -51,7 +51,7 @@ Name | Type | Description |
 
 • **baseurl**: *string*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L33)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **core**: *[SlopesCore](_slopes_.slopescore.md)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L32)*
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 • **db**: *StoreAPI*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L34)*
 
 ## Methods
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **getBaseURL**(): *string*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -87,7 +87,7 @@ ___
 
 ▸ **getDB**(): *StoreAPI*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **setBaseURL**(`baseurl`: string): *void*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.defaults.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.defaults.md
@@ -18,19 +18,19 @@
 
 ### ▪ **network**: *object*
 
-*Defined in [utils/types.ts:517](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L517)*
+*Defined in [utils/types.ts:517](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L517)*
 
 ###  1
 
 • **1**: *object*
 
-*Defined in [utils/types.ts:518](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L518)*
+*Defined in [utils/types.ts:518](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L518)*
 
 #### Type declaration:
 
 ▪ **12345**: *object*
 
-*Defined in [utils/types.ts:541](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L541)*
+*Defined in [utils/types.ts:541](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L541)*
 
 * **11111111111111111111111111111111LpoYY**: *object & object* =  n12345_platform
 
@@ -52,7 +52,7 @@
 
 ▪ **2**: *object*
 
-*Defined in [utils/types.ts:519](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L519)*
+*Defined in [utils/types.ts:519](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L519)*
 
 * **11111111111111111111111111111111LpoYY**: *object* =  n2_platform
 
@@ -74,7 +74,7 @@
 
 ▪ **3**: *object*
 
-*Defined in [utils/types.ts:530](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L530)*
+*Defined in [utils/types.ts:530](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L530)*
 
 * **11111111111111111111111111111111LpoYY**: *object* =  n3_platform
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.defaults.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.defaults.md
@@ -18,19 +18,19 @@
 
 ### ▪ **network**: *object*
 
-*Defined in [utils/types.ts:517](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L517)*
+*Defined in [utils/types.ts:517](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L517)*
 
 ###  1
 
 • **1**: *object*
 
-*Defined in [utils/types.ts:518](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L518)*
+*Defined in [utils/types.ts:518](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L518)*
 
 #### Type declaration:
 
 ▪ **12345**: *object*
 
-*Defined in [utils/types.ts:541](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L541)*
+*Defined in [utils/types.ts:541](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L541)*
 
 * **11111111111111111111111111111111LpoYY**: *object & object* =  n12345_platform
 
@@ -52,7 +52,7 @@
 
 ▪ **2**: *object*
 
-*Defined in [utils/types.ts:519](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L519)*
+*Defined in [utils/types.ts:519](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L519)*
 
 * **11111111111111111111111111111111LpoYY**: *object* =  n2_platform
 
@@ -74,7 +74,7 @@
 
 ▪ **3**: *object*
 
-*Defined in [utils/types.ts:530](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L530)*
+*Defined in [utils/types.ts:530](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L530)*
 
 * **11111111111111111111111111111111LpoYY**: *object* =  n3_platform
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.jrpcapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.jrpcapi.md
@@ -46,7 +46,7 @@
 
 *Overrides [APIBase](_utils_types_.apibase.md).[constructor](_utils_types_.apibase.md#constructor)*
 
-*Defined in [utils/types.ts:126](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L126)*
+*Defined in [utils/types.ts:126](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L126)*
 
 **Parameters:**
 
@@ -66,7 +66,7 @@ Name | Type | Default | Description |
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • **jrpcVersion**: *string* = "2.0"
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • **rpcid**: *number* = 1
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -110,7 +110,7 @@ ___
 
 ▸ **callMethod**(`method`: string, `params?`: Array‹object› | object, `baseurl?`: string): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -130,7 +130,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -144,7 +144,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **getRPCID**(): *number*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -170,7 +170,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.jrpcapi.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.jrpcapi.md
@@ -46,7 +46,7 @@
 
 *Overrides [APIBase](_utils_types_.apibase.md).[constructor](_utils_types_.apibase.md#constructor)*
 
-*Defined in [utils/types.ts:126](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L126)*
+*Defined in [utils/types.ts:126](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L126)*
 
 **Parameters:**
 
@@ -66,7 +66,7 @@ Name | Type | Default | Description |
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[baseurl](_utils_types_.apibase.md#protected-baseurl)*
 
-*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L33)*
+*Defined in [utils/types.ts:33](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L33)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[core](_utils_types_.apibase.md#protected-core)*
 
-*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L32)*
+*Defined in [utils/types.ts:32](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L32)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md).[db](_utils_types_.apibase.md#protected-db)*
 
-*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L34)*
+*Defined in [utils/types.ts:34](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L34)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • **jrpcVersion**: *string* = "2.0"
 
-*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L80)*
+*Defined in [utils/types.ts:80](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L80)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • **rpcid**: *number* = 1
 
-*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L81)*
+*Defined in [utils/types.ts:81](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L81)*
 
 ## Methods
 
@@ -110,7 +110,7 @@ ___
 
 ▸ **callMethod**(`method`: string, `params?`: Array‹object› | object, `baseurl?`: string): *Promise‹[RequestResponseData](_utils_types_.requestresponsedata.md)›*
 
-*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L82)*
+*Defined in [utils/types.ts:82](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L82)*
 
 **Parameters:**
 
@@ -130,7 +130,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L57)*
+*Defined in [utils/types.ts:57](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L57)*
 
 Returns the baseurl's path.
 
@@ -144,7 +144,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L64)*
+*Defined in [utils/types.ts:64](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L64)*
 
 Returns the baseurl's database.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **getRPCID**(): *number*
 
-*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L124)*
+*Defined in [utils/types.ts:124](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L124)*
 
 Returns the rpcid, a strictly-increasing number, starting from 1, indicating the next request ID that will be sent.
 
@@ -170,7 +170,7 @@ ___
 
 *Inherited from [APIBase](_utils_types_.apibase.md)*
 
-*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L41)*
+*Defined in [utils/types.ts:41](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L41)*
 
 Sets the path of the APIs baseurl.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.keychain.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.keychain.md
@@ -47,7 +47,7 @@ extending [KeyPair](_utils_types_.keypair.md) which is used as the key in [KeyCh
 
 \+ **new KeyChain**(`chainid`: string): *[KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:383](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L383)*
+*Defined in [utils/types.ts:383](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L383)*
 
 Returns instance of [KeyChain](_utils_types_.keychain.md).
 
@@ -65,7 +65,7 @@ Name | Type |
 
 • **chainid**: *string* = ""
 
-*Defined in [utils/types.ts:272](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L272)*
+*Defined in [utils/types.ts:272](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L272)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **importKey**: *function*
 
-*Defined in [utils/types.ts:290](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L290)*
+*Defined in [utils/types.ts:290](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L290)*
 
 Given a private key, makes a new [KeyPair](_utils_types_.keypair.md), returns the address.
 
@@ -97,7 +97,7 @@ ___
 
 • **keys**: *object*
 
-*Defined in [utils/types.ts:271](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L271)*
+*Defined in [utils/types.ts:271](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L271)*
 
 #### Type declaration:
 
@@ -109,7 +109,7 @@ ___
 
 • **makeKey**: *function*
 
-*Defined in [utils/types.ts:281](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L281)*
+*Defined in [utils/types.ts:281](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L281)*
 
 Makes a new [KeyPair](_utils_types_.keypair.md), returns the address.
 
@@ -133,7 +133,7 @@ Name | Type |
 
 ▸ **addKey**(`newKey`: KPClass): *void*
 
-*Defined in [utils/types.ts:315](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L315)*
+*Defined in [utils/types.ts:315](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L315)*
 
 Adds the key pair to the list of the keys managed in the [KeyChain](_utils_types_.keychain.md).
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **getAddressStrings**(): *Array‹string›*
 
-*Defined in [utils/types.ts:306](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L306)*
+*Defined in [utils/types.ts:306](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L306)*
 
 Gets an array of addresses stored in the [KeyChain](_utils_types_.keychain.md).
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **getAddresses**(): *Array‹Buffer›*
 
-*Defined in [utils/types.ts:297](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L297)*
+*Defined in [utils/types.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L297)*
 
 Gets an array of addresses stored in the [KeyChain](_utils_types_.keychain.md).
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **getChainID**(): *string*
 
-*Defined in [utils/types.ts:369](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L369)*
+*Defined in [utils/types.ts:369](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L369)*
 
 Returns the chainID associated with this [KeyChain](_utils_types_.keychain.md).
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **getKey**(`address`: Buffer): *KPClass*
 
-*Defined in [utils/types.ts:360](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L360)*
+*Defined in [utils/types.ts:360](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L360)*
 
 Returns the [KeyPair](_utils_types_.keypair.md) listed under the provided address
 
@@ -213,7 +213,7 @@ ___
 
 ▸ **hasKey**(`address`: Buffer): *boolean*
 
-*Defined in [utils/types.ts:349](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L349)*
+*Defined in [utils/types.ts:349](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L349)*
 
 Checks if there is a key associated with the provided address.
 
@@ -233,7 +233,7 @@ ___
 
 ▸ **removeKey**(`key`: KPClass | Buffer): *boolean*
 
-*Defined in [utils/types.ts:327](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L327)*
+*Defined in [utils/types.ts:327](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L327)*
 
 Removes the key pair from the list of they keys managed in the [KeyChain](_utils_types_.keychain.md).
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **setChainID**(`chainid`: string): *void*
 
-*Defined in [utils/types.ts:378](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L378)*
+*Defined in [utils/types.ts:378](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L378)*
 
 Sets the the chainID associated with this [KeyChain](_utils_types_.keychain.md) and all associated keypairs.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.keychain.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.keychain.md
@@ -47,7 +47,7 @@ extending [KeyPair](_utils_types_.keypair.md) which is used as the key in [KeyCh
 
 \+ **new KeyChain**(`chainid`: string): *[KeyChain](_utils_types_.keychain.md)*
 
-*Defined in [utils/types.ts:383](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L383)*
+*Defined in [utils/types.ts:383](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L383)*
 
 Returns instance of [KeyChain](_utils_types_.keychain.md).
 
@@ -65,7 +65,7 @@ Name | Type |
 
 • **chainid**: *string* = ""
 
-*Defined in [utils/types.ts:272](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L272)*
+*Defined in [utils/types.ts:272](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L272)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **importKey**: *function*
 
-*Defined in [utils/types.ts:290](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L290)*
+*Defined in [utils/types.ts:290](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L290)*
 
 Given a private key, makes a new [KeyPair](_utils_types_.keypair.md), returns the address.
 
@@ -97,7 +97,7 @@ ___
 
 • **keys**: *object*
 
-*Defined in [utils/types.ts:271](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L271)*
+*Defined in [utils/types.ts:271](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L271)*
 
 #### Type declaration:
 
@@ -109,7 +109,7 @@ ___
 
 • **makeKey**: *function*
 
-*Defined in [utils/types.ts:281](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L281)*
+*Defined in [utils/types.ts:281](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L281)*
 
 Makes a new [KeyPair](_utils_types_.keypair.md), returns the address.
 
@@ -133,7 +133,7 @@ Name | Type |
 
 ▸ **addKey**(`newKey`: KPClass): *void*
 
-*Defined in [utils/types.ts:315](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L315)*
+*Defined in [utils/types.ts:315](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L315)*
 
 Adds the key pair to the list of the keys managed in the [KeyChain](_utils_types_.keychain.md).
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **getAddressStrings**(): *Array‹string›*
 
-*Defined in [utils/types.ts:306](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L306)*
+*Defined in [utils/types.ts:306](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L306)*
 
 Gets an array of addresses stored in the [KeyChain](_utils_types_.keychain.md).
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **getAddresses**(): *Array‹Buffer›*
 
-*Defined in [utils/types.ts:297](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L297)*
+*Defined in [utils/types.ts:297](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L297)*
 
 Gets an array of addresses stored in the [KeyChain](_utils_types_.keychain.md).
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **getChainID**(): *string*
 
-*Defined in [utils/types.ts:369](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L369)*
+*Defined in [utils/types.ts:369](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L369)*
 
 Returns the chainID associated with this [KeyChain](_utils_types_.keychain.md).
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **getKey**(`address`: Buffer): *KPClass*
 
-*Defined in [utils/types.ts:360](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L360)*
+*Defined in [utils/types.ts:360](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L360)*
 
 Returns the [KeyPair](_utils_types_.keypair.md) listed under the provided address
 
@@ -213,7 +213,7 @@ ___
 
 ▸ **hasKey**(`address`: Buffer): *boolean*
 
-*Defined in [utils/types.ts:349](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L349)*
+*Defined in [utils/types.ts:349](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L349)*
 
 Checks if there is a key associated with the provided address.
 
@@ -233,7 +233,7 @@ ___
 
 ▸ **removeKey**(`key`: KPClass | Buffer): *boolean*
 
-*Defined in [utils/types.ts:327](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L327)*
+*Defined in [utils/types.ts:327](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L327)*
 
 Removes the key pair from the list of they keys managed in the [KeyChain](_utils_types_.keychain.md).
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **setChainID**(`chainid`: string): *void*
 
-*Defined in [utils/types.ts:378](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L378)*
+*Defined in [utils/types.ts:378](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L378)*
 
 Sets the the chainID associated with this [KeyChain](_utils_types_.keychain.md) and all associated keypairs.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.keypair.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.keypair.md
@@ -45,7 +45,7 @@ All APIs that need key pairs should extend on this class.
 
 \+ **new KeyPair**(`chainid`: string): *[KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:257](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L257)*
+*Defined in [utils/types.ts:257](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L257)*
 
 **Parameters:**
 
@@ -61,7 +61,7 @@ Name | Type |
 
 • **chainid**: *string* = ""
 
-*Defined in [utils/types.ts:148](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L148)*
+*Defined in [utils/types.ts:148](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L148)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **generateKey**: *function*
 
-*Defined in [utils/types.ts:155](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L155)*
+*Defined in [utils/types.ts:155](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L155)*
 
 Generates a new keypair.
 
@@ -91,7 +91,7 @@ ___
 
 • **getAddress**: *function*
 
-*Defined in [utils/types.ts:232](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L232)*
+*Defined in [utils/types.ts:232](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L232)*
 
 Returns the address.
 
@@ -107,7 +107,7 @@ ___
 
 • **getAddressString**: *function*
 
-*Defined in [utils/types.ts:239](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L239)*
+*Defined in [utils/types.ts:239](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L239)*
 
 Returns the address's string representation.
 
@@ -123,7 +123,7 @@ ___
 
 • **getPrivateKeyString**: *function*
 
-*Defined in [utils/types.ts:218](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L218)*
+*Defined in [utils/types.ts:218](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L218)*
 
 Returns a string representation of the private key.
 
@@ -139,7 +139,7 @@ ___
 
 • **getPublicKeyString**: *function*
 
-*Defined in [utils/types.ts:225](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L225)*
+*Defined in [utils/types.ts:225](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L225)*
 
 Returns the public key.
 
@@ -155,7 +155,7 @@ ___
 
 • **importKey**: *function*
 
-*Defined in [utils/types.ts:163](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L163)*
+*Defined in [utils/types.ts:163](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L163)*
 
 Imports a private key and generates the appropriate public key.
 
@@ -179,7 +179,7 @@ ___
 
 • **privk**: *Buffer*
 
-*Defined in [utils/types.ts:147](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L147)*
+*Defined in [utils/types.ts:147](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L147)*
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 • **pubk**: *Buffer*
 
-*Defined in [utils/types.ts:146](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L146)*
+*Defined in [utils/types.ts:146](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L146)*
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 • **recover**: *function*
 
-*Defined in [utils/types.ts:182](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L182)*
+*Defined in [utils/types.ts:182](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L182)*
 
 Recovers the public key of a message signer from a message and its associated signature.
 
@@ -222,7 +222,7 @@ ___
 
 • **sign**: *function*
 
-*Defined in [utils/types.ts:172](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L172)*
+*Defined in [utils/types.ts:172](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L172)*
 
 Takes a message, signs it, and returns the signature.
 
@@ -246,7 +246,7 @@ ___
 
 • **verify**: *function*
 
-*Defined in [utils/types.ts:193](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L193)*
+*Defined in [utils/types.ts:193](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L193)*
 
 Verifies that the private key associated with the provided public key produces the signature associated with the given message.
 
@@ -276,7 +276,7 @@ Name | Type |
 
 ▸ **getChainID**(): *string*
 
-*Defined in [utils/types.ts:246](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L246)*
+*Defined in [utils/types.ts:246](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L246)*
 
 Returns the chainID associated with this key.
 
@@ -290,7 +290,7 @@ ___
 
 ▸ **getPrivateKey**(): *Buffer*
 
-*Defined in [utils/types.ts:200](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L200)*
+*Defined in [utils/types.ts:200](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L200)*
 
 Returns a reference to the private key.
 
@@ -304,7 +304,7 @@ ___
 
 ▸ **getPublicKey**(): *Buffer*
 
-*Defined in [utils/types.ts:209](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L209)*
+*Defined in [utils/types.ts:209](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L209)*
 
 Returns a reference to the public key.
 
@@ -318,7 +318,7 @@ ___
 
 ▸ **setChainID**(`chainid`: string): *void*
 
-*Defined in [utils/types.ts:255](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L255)*
+*Defined in [utils/types.ts:255](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L255)*
 
 Sets the the chainID associated with this key.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.keypair.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.keypair.md
@@ -45,7 +45,7 @@ All APIs that need key pairs should extend on this class.
 
 \+ **new KeyPair**(`chainid`: string): *[KeyPair](_utils_types_.keypair.md)*
 
-*Defined in [utils/types.ts:257](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L257)*
+*Defined in [utils/types.ts:257](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L257)*
 
 **Parameters:**
 
@@ -61,7 +61,7 @@ Name | Type |
 
 • **chainid**: *string* = ""
 
-*Defined in [utils/types.ts:148](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L148)*
+*Defined in [utils/types.ts:148](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L148)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **generateKey**: *function*
 
-*Defined in [utils/types.ts:155](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L155)*
+*Defined in [utils/types.ts:155](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L155)*
 
 Generates a new keypair.
 
@@ -91,7 +91,7 @@ ___
 
 • **getAddress**: *function*
 
-*Defined in [utils/types.ts:232](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L232)*
+*Defined in [utils/types.ts:232](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L232)*
 
 Returns the address.
 
@@ -107,7 +107,7 @@ ___
 
 • **getAddressString**: *function*
 
-*Defined in [utils/types.ts:239](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L239)*
+*Defined in [utils/types.ts:239](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L239)*
 
 Returns the address's string representation.
 
@@ -123,7 +123,7 @@ ___
 
 • **getPrivateKeyString**: *function*
 
-*Defined in [utils/types.ts:218](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L218)*
+*Defined in [utils/types.ts:218](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L218)*
 
 Returns a string representation of the private key.
 
@@ -139,7 +139,7 @@ ___
 
 • **getPublicKeyString**: *function*
 
-*Defined in [utils/types.ts:225](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L225)*
+*Defined in [utils/types.ts:225](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L225)*
 
 Returns the public key.
 
@@ -155,7 +155,7 @@ ___
 
 • **importKey**: *function*
 
-*Defined in [utils/types.ts:163](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L163)*
+*Defined in [utils/types.ts:163](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L163)*
 
 Imports a private key and generates the appropriate public key.
 
@@ -179,7 +179,7 @@ ___
 
 • **privk**: *Buffer*
 
-*Defined in [utils/types.ts:147](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L147)*
+*Defined in [utils/types.ts:147](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L147)*
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 • **pubk**: *Buffer*
 
-*Defined in [utils/types.ts:146](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L146)*
+*Defined in [utils/types.ts:146](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L146)*
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 • **recover**: *function*
 
-*Defined in [utils/types.ts:182](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L182)*
+*Defined in [utils/types.ts:182](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L182)*
 
 Recovers the public key of a message signer from a message and its associated signature.
 
@@ -222,7 +222,7 @@ ___
 
 • **sign**: *function*
 
-*Defined in [utils/types.ts:172](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L172)*
+*Defined in [utils/types.ts:172](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L172)*
 
 Takes a message, signs it, and returns the signature.
 
@@ -246,7 +246,7 @@ ___
 
 • **verify**: *function*
 
-*Defined in [utils/types.ts:193](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L193)*
+*Defined in [utils/types.ts:193](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L193)*
 
 Verifies that the private key associated with the provided public key produces the signature associated with the given message.
 
@@ -276,7 +276,7 @@ Name | Type |
 
 ▸ **getChainID**(): *string*
 
-*Defined in [utils/types.ts:246](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L246)*
+*Defined in [utils/types.ts:246](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L246)*
 
 Returns the chainID associated with this key.
 
@@ -290,7 +290,7 @@ ___
 
 ▸ **getPrivateKey**(): *Buffer*
 
-*Defined in [utils/types.ts:200](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L200)*
+*Defined in [utils/types.ts:200](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L200)*
 
 Returns a reference to the private key.
 
@@ -304,7 +304,7 @@ ___
 
 ▸ **getPublicKey**(): *Buffer*
 
-*Defined in [utils/types.ts:209](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L209)*
+*Defined in [utils/types.ts:209](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L209)*
 
 Returns a reference to the public key.
 
@@ -318,7 +318,7 @@ ___
 
 ▸ **setChainID**(`chainid`: string): *void*
 
-*Defined in [utils/types.ts:255](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L255)*
+*Defined in [utils/types.ts:255](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L255)*
 
 Sets the the chainID associated with this key.
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.nbytes.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.nbytes.md
@@ -43,7 +43,7 @@ Create a class that extends this one and override bsize to make it validate for 
 
 \+ **new NBytes**(): *[NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:466](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L466)*
+*Defined in [utils/types.ts:466](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L466)*
 
 Returns instance of [NBytes](_utils_types_.nbytes.md).
 
@@ -55,7 +55,7 @@ Returns instance of [NBytes](_utils_types_.nbytes.md).
 
 • **bsize**: *number*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L400)*
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 • **bytes**: *Buffer*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L399)*
 
 ## Methods
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **fromBuffer**(`buff`: Buffer, `offset`: number): *number*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **fromString**(`b58str`: string): *number*
 
-*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L416)*
+*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L416)*
 
 Takes a base-58 encoded string, verifies its length, and stores it.
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **getSize**(): *number*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -126,7 +126,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L464)*
+*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L464)*
 
 Returns a base-58 string of the stored [Buffer](https://github.com/feross/buffer).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.nbytes.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.nbytes.md
@@ -43,7 +43,7 @@ Create a class that extends this one and override bsize to make it validate for 
 
 \+ **new NBytes**(): *[NBytes](_utils_types_.nbytes.md)*
 
-*Defined in [utils/types.ts:466](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L466)*
+*Defined in [utils/types.ts:466](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L466)*
 
 Returns instance of [NBytes](_utils_types_.nbytes.md).
 
@@ -55,7 +55,7 @@ Returns instance of [NBytes](_utils_types_.nbytes.md).
 
 • **bsize**: *number*
 
-*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L400)*
+*Defined in [utils/types.ts:400](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L400)*
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 • **bytes**: *Buffer*
 
-*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L399)*
+*Defined in [utils/types.ts:399](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L399)*
 
 ## Methods
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **fromBuffer**(`buff`: Buffer, `offset`: number): *number*
 
-*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L433)*
+*Defined in [utils/types.ts:433](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L433)*
 
 Takes a [[Buffer]], verifies its length, and stores it.
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **fromString**(`b58str`: string): *number*
 
-*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L416)*
+*Defined in [utils/types.ts:416](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L416)*
 
 Takes a base-58 encoded string, verifies its length, and stores it.
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **getSize**(): *number*
 
-*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L407)*
+*Defined in [utils/types.ts:407](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L407)*
 
 Returns the length of the [Buffer](https://github.com/feross/buffer).
 
@@ -126,7 +126,7 @@ ___
 
 ▸ **toBuffer**(): *Buffer*
 
-*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L455)*
+*Defined in [utils/types.ts:455](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L455)*
 
 Returns the stored [Buffer](https://github.com/feross/buffer).
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L464)*
+*Defined in [utils/types.ts:464](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L464)*
 
 Returns a base-58 string of the stored [Buffer](https://github.com/feross/buffer).
 

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.requestresponsedata.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.requestresponsedata.md
@@ -24,7 +24,7 @@ Response data for HTTP requests.
 
 • **data**: *string | object | Array‹object›*
 
-*Defined in [utils/types.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L21)*
+*Defined in [utils/types.ts:21](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L21)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **headers**: *object*
 
-*Defined in [utils/types.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L22)*
+*Defined in [utils/types.ts:22](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L22)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **request**: *ClientRequest | XMLHttpRequest*
 
-*Defined in [utils/types.ts:25](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L25)*
+*Defined in [utils/types.ts:25](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L25)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **status**: *number*
 
-*Defined in [utils/types.ts:23](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L23)*
+*Defined in [utils/types.ts:23](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L23)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • **statusText**: *string*
 
-*Defined in [utils/types.ts:24](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L24)*
+*Defined in [utils/types.ts:24](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L24)*

--- a/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.requestresponsedata.md
+++ b/docs/v1.0/en/tools/slopes/api/classes/_utils_types_.requestresponsedata.md
@@ -24,7 +24,7 @@ Response data for HTTP requests.
 
 • **data**: *string | object | Array‹object›*
 
-*Defined in [utils/types.ts:21](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L21)*
+*Defined in [utils/types.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L21)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **headers**: *object*
 
-*Defined in [utils/types.ts:22](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L22)*
+*Defined in [utils/types.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L22)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **request**: *ClientRequest | XMLHttpRequest*
 
-*Defined in [utils/types.ts:25](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L25)*
+*Defined in [utils/types.ts:25](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L25)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **status**: *number*
 
-*Defined in [utils/types.ts:23](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L23)*
+*Defined in [utils/types.ts:23](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L23)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • **statusText**: *string*
 
-*Defined in [utils/types.ts:24](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L24)*
+*Defined in [utils/types.ts:24](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L24)*

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_credentials_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_credentials_.md
@@ -20,7 +20,7 @@
 
 ▸ **SelectCredentialClass**(`credid`: number, ...`args`: Array‹any›): *[Credential](../classes/_apis_avm_credentials_.credential.md)*
 
-*Defined in [apis/avm/credentials.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L22)*
+*Defined in [apis/avm/credentials.ts:22](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/credentials.ts#L22)*
 
 Takes a buffer representing the credential and returns the proper [Credential](../classes/_apis_avm_credentials_.credential.md) instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_credentials_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_credentials_.md
@@ -20,7 +20,7 @@
 
 ▸ **SelectCredentialClass**(`credid`: number, ...`args`: Array‹any›): *[Credential](../classes/_apis_avm_credentials_.credential.md)*
 
-*Defined in [apis/avm/credentials.ts:22](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/credentials.ts#L22)*
+*Defined in [apis/avm/credentials.ts:22](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/credentials.ts#L22)*
 
 Takes a buffer representing the credential and returns the proper [Credential](../classes/_apis_avm_credentials_.credential.md) instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_inputs_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_inputs_.md
@@ -21,7 +21,7 @@
 
 ▸ **SelectInputClass**(`inputid`: number, ...`args`: Array‹any›): *[Input](../classes/_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:21](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/inputs.ts#L21)*
+*Defined in [apis/avm/inputs.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L21)*
 
 Takes a buffer representing the output and returns the proper [Input](../classes/_apis_avm_inputs_.input.md) instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_inputs_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_inputs_.md
@@ -21,7 +21,7 @@
 
 ▸ **SelectInputClass**(`inputid`: number, ...`args`: Array‹any›): *[Input](../classes/_apis_avm_inputs_.input.md)*
 
-*Defined in [apis/avm/inputs.ts:21](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/inputs.ts#L21)*
+*Defined in [apis/avm/inputs.ts:21](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/inputs.ts#L21)*
 
 Takes a buffer representing the output and returns the proper [Input](../classes/_apis_avm_inputs_.input.md) instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_ops_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_ops_.md
@@ -24,7 +24,7 @@
 
 • **bintools**: *[BinTools](../classes/_utils_bintools_.bintools.md)‹›* =  BinTools.getInstance()
 
-*Defined in [apis/avm/ops.ts:9](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L9)*
+*Defined in [apis/avm/ops.ts:9](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L9)*
 
 ## Functions
 
@@ -32,7 +32,7 @@
 
 ▸ **SelectOperationClass**(`opid`: number, ...`args`: Array‹any›): *[Operation](../classes/_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:18](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L18)*
+*Defined in [apis/avm/ops.ts:18](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/ops.ts#L18)*
 
 Takes a buffer representing the output and returns the proper [Operation](../classes/_apis_avm_ops_.operation.md) instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_ops_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_ops_.md
@@ -24,7 +24,7 @@
 
 • **bintools**: *[BinTools](../classes/_utils_bintools_.bintools.md)‹›* =  BinTools.getInstance()
 
-*Defined in [apis/avm/ops.ts:9](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L9)*
+*Defined in [apis/avm/ops.ts:9](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L9)*
 
 ## Functions
 
@@ -32,7 +32,7 @@
 
 ▸ **SelectOperationClass**(`opid`: number, ...`args`: Array‹any›): *[Operation](../classes/_apis_avm_ops_.operation.md)*
 
-*Defined in [apis/avm/ops.ts:18](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/ops.ts#L18)*
+*Defined in [apis/avm/ops.ts:18](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/ops.ts#L18)*
 
 Takes a buffer representing the output and returns the proper [Operation](../classes/_apis_avm_ops_.operation.md) instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_outputs_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_outputs_.md
@@ -27,7 +27,7 @@
 
 • **bintools**: *[BinTools](../classes/_utils_bintools_.bintools.md)‹›* =  BinTools.getInstance()
 
-*Defined in [apis/avm/outputs.ts:9](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L9)*
+*Defined in [apis/avm/outputs.ts:9](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L9)*
 
 ## Functions
 
@@ -35,7 +35,7 @@
 
 ▸ **SelectOutputClass**(`outputid`: number, ...`args`: Array‹any›): *[Output](../classes/_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:18](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L18)*
+*Defined in [apis/avm/outputs.ts:18](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/outputs.ts#L18)*
 
 Takes a buffer representing the output and returns the proper Output instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_outputs_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_outputs_.md
@@ -27,7 +27,7 @@
 
 • **bintools**: *[BinTools](../classes/_utils_bintools_.bintools.md)‹›* =  BinTools.getInstance()
 
-*Defined in [apis/avm/outputs.ts:9](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L9)*
+*Defined in [apis/avm/outputs.ts:9](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L9)*
 
 ## Functions
 
@@ -35,7 +35,7 @@
 
 ▸ **SelectOutputClass**(`outputid`: number, ...`args`: Array‹any›): *[Output](../classes/_apis_avm_outputs_.output.md)*
 
-*Defined in [apis/avm/outputs.ts:18](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/outputs.ts#L18)*
+*Defined in [apis/avm/outputs.ts:18](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/outputs.ts#L18)*
 
 Takes a buffer representing the output and returns the proper Output instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_tx_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_tx_.md
@@ -22,7 +22,7 @@
 
 ▸ **SelectTxClass**(`txtype`: number, ...`args`: Array‹any›): *[BaseTx](../classes/_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L26)*
+*Defined in [apis/avm/tx.ts:26](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/tx.ts#L26)*
 
 Takes a buffer representing the output and returns the proper [BaseTx](../classes/_apis_avm_tx_.basetx.md) instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_tx_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_tx_.md
@@ -22,7 +22,7 @@
 
 ▸ **SelectTxClass**(`txtype`: number, ...`args`: Array‹any›): *[BaseTx](../classes/_apis_avm_tx_.basetx.md)*
 
-*Defined in [apis/avm/tx.ts:26](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/tx.ts#L26)*
+*Defined in [apis/avm/tx.ts:26](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/tx.ts#L26)*
 
 Takes a buffer representing the output and returns the proper [BaseTx](../classes/_apis_avm_tx_.basetx.md) instance.
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_types_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_types_.md
@@ -27,7 +27,7 @@
 
 Ƭ **MergeRule**: *"intersection" | "differenceSelf" | "differenceNew" | "symDifference" | "union" | "unionMinusNew" | "unionMinusSelf" | "ERROR"*
 
-*Defined in [apis/avm/types.ts:267](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L267)*
+*Defined in [apis/avm/types.ts:267](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L267)*
 
 Rules used when merging sets
 
@@ -37,7 +37,7 @@ Rules used when merging sets
 
 ▸ **UnixNow**(): *BN*
 
-*Defined in [apis/avm/types.ts:279](https://github.com/ava-labs/slopes/blob/2d2915d/src/apis/avm/types.ts#L279)*
+*Defined in [apis/avm/types.ts:279](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L279)*
 
 Function providing the current UNIX time using a [BN](https://github.com/indutny/bn.js/)
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_types_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_apis_avm_types_.md
@@ -27,7 +27,7 @@
 
 Ƭ **MergeRule**: *"intersection" | "differenceSelf" | "differenceNew" | "symDifference" | "union" | "unionMinusNew" | "unionMinusSelf" | "ERROR"*
 
-*Defined in [apis/avm/types.ts:267](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L267)*
+*Defined in [apis/avm/types.ts:267](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L267)*
 
 Rules used when merging sets
 
@@ -37,7 +37,7 @@ Rules used when merging sets
 
 ▸ **UnixNow**(): *BN*
 
-*Defined in [apis/avm/types.ts:279](https://github.com/ava-labs/slopes/blob/65cee65/src/apis/avm/types.ts#L279)*
+*Defined in [apis/avm/types.ts:279](https://github.com/ava-labs/slopes/blob/ba50532/src/apis/avm/types.ts#L279)*
 
 Function providing the current UNIX time using a [BN](https://github.com/indutny/bn.js/)
 

--- a/docs/v1.0/en/tools/slopes/api/modules/_utils_types_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_utils_types_.md
@@ -35,7 +35,7 @@
 
 • **n12345_avm**: *object* =  Object.assign({}, n2_avm)
 
-*Defined in [utils/types.ts:509](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L509)*
+*Defined in [utils/types.ts:509](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L509)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **n12345_contracts**: *object & object* =  Object.assign({}, n2_contracts)
 
-*Defined in [utils/types.ts:513](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L513)*
+*Defined in [utils/types.ts:513](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L513)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 • **n12345_platform**: *object & object* =  Object.assign({}, n2_platform)
 
-*Defined in [utils/types.ts:511](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L511)*
+*Defined in [utils/types.ts:511](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L511)*
 
 ## Object literals
 
@@ -59,25 +59,25 @@ ___
 
 ### ▪ **n2_avm**: *object*
 
-*Defined in [utils/types.ts:473](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L473)*
+*Defined in [utils/types.ts:473](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L473)*
 
 ###  alias
 
 • **alias**: *string* = "X"
 
-*Defined in [utils/types.ts:475](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L475)*
+*Defined in [utils/types.ts:475](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L475)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "4ktRjsAKxgMr2aEzv9SWmrU7Xk5FniHUrVCX4P1TZSfTLZWFM"
 
-*Defined in [utils/types.ts:474](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L474)*
+*Defined in [utils/types.ts:474](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L474)*
 
 ###  vm
 
 • **vm**: *string* = "avm"
 
-*Defined in [utils/types.ts:476](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L476)*
+*Defined in [utils/types.ts:476](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L476)*
 
 ___
 
@@ -85,25 +85,25 @@ ___
 
 ### ▪ **n2_contracts**: *object*
 
-*Defined in [utils/types.ts:485](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L485)*
+*Defined in [utils/types.ts:485](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L485)*
 
 ###  alias
 
 • **alias**: *string* = "C"
 
-*Defined in [utils/types.ts:487](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L487)*
+*Defined in [utils/types.ts:487](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L487)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "2mUYSXfLrDtigwbzj1LxKVsHwELghc5sisoXrzJwLqAAQHF4i"
 
-*Defined in [utils/types.ts:486](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L486)*
+*Defined in [utils/types.ts:486](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L486)*
 
 ###  vm
 
 • **vm**: *string* = "contracts"
 
-*Defined in [utils/types.ts:488](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L488)*
+*Defined in [utils/types.ts:488](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L488)*
 
 ___
 
@@ -111,25 +111,25 @@ ___
 
 ### ▪ **n2_platform**: *object*
 
-*Defined in [utils/types.ts:479](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L479)*
+*Defined in [utils/types.ts:479](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L479)*
 
 ###  alias
 
 • **alias**: *string* = "P"
 
-*Defined in [utils/types.ts:481](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L481)*
+*Defined in [utils/types.ts:481](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L481)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "11111111111111111111111111111111LpoYY"
 
-*Defined in [utils/types.ts:480](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L480)*
+*Defined in [utils/types.ts:480](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L480)*
 
 ###  vm
 
 • **vm**: *string* = "platform"
 
-*Defined in [utils/types.ts:482](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L482)*
+*Defined in [utils/types.ts:482](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L482)*
 
 ___
 
@@ -137,25 +137,25 @@ ___
 
 ### ▪ **n3_avm**: *object*
 
-*Defined in [utils/types.ts:491](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L491)*
+*Defined in [utils/types.ts:491](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L491)*
 
 ###  alias
 
 • **alias**: *string* = "X"
 
-*Defined in [utils/types.ts:493](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L493)*
+*Defined in [utils/types.ts:493](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L493)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "rrEWX7gc7D9mwcdrdBxBTdqh1a7WDVsMuadhTZgyXfFcRz45L"
 
-*Defined in [utils/types.ts:492](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L492)*
+*Defined in [utils/types.ts:492](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L492)*
 
 ###  vm
 
 • **vm**: *string* = "avm"
 
-*Defined in [utils/types.ts:494](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L494)*
+*Defined in [utils/types.ts:494](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L494)*
 
 ___
 
@@ -163,25 +163,25 @@ ___
 
 ### ▪ **n3_contracts**: *object*
 
-*Defined in [utils/types.ts:503](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L503)*
+*Defined in [utils/types.ts:503](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L503)*
 
 ###  alias
 
 • **alias**: *string* = "C"
 
-*Defined in [utils/types.ts:505](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L505)*
+*Defined in [utils/types.ts:505](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L505)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "zJytnh96Pc8rM337bBrtMvJDbEdDNjcXG3WkTNCiLp18ergm9"
 
-*Defined in [utils/types.ts:504](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L504)*
+*Defined in [utils/types.ts:504](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L504)*
 
 ###  vm
 
 • **vm**: *string* = "contracts"
 
-*Defined in [utils/types.ts:506](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L506)*
+*Defined in [utils/types.ts:506](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L506)*
 
 ___
 
@@ -189,22 +189,22 @@ ___
 
 ### ▪ **n3_platform**: *object*
 
-*Defined in [utils/types.ts:497](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L497)*
+*Defined in [utils/types.ts:497](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L497)*
 
 ###  alias
 
 • **alias**: *string* = "P"
 
-*Defined in [utils/types.ts:499](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L499)*
+*Defined in [utils/types.ts:499](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L499)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "11111111111111111111111111111111LpoYY"
 
-*Defined in [utils/types.ts:498](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L498)*
+*Defined in [utils/types.ts:498](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L498)*
 
 ###  vm
 
 • **vm**: *string* = "platform"
 
-*Defined in [utils/types.ts:500](https://github.com/ava-labs/slopes/blob/2d2915d/src/utils/types.ts#L500)*
+*Defined in [utils/types.ts:500](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L500)*

--- a/docs/v1.0/en/tools/slopes/api/modules/_utils_types_.md
+++ b/docs/v1.0/en/tools/slopes/api/modules/_utils_types_.md
@@ -35,7 +35,7 @@
 
 • **n12345_avm**: *object* =  Object.assign({}, n2_avm)
 
-*Defined in [utils/types.ts:509](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L509)*
+*Defined in [utils/types.ts:509](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L509)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **n12345_contracts**: *object & object* =  Object.assign({}, n2_contracts)
 
-*Defined in [utils/types.ts:513](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L513)*
+*Defined in [utils/types.ts:513](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L513)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 • **n12345_platform**: *object & object* =  Object.assign({}, n2_platform)
 
-*Defined in [utils/types.ts:511](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L511)*
+*Defined in [utils/types.ts:511](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L511)*
 
 ## Object literals
 
@@ -59,25 +59,25 @@ ___
 
 ### ▪ **n2_avm**: *object*
 
-*Defined in [utils/types.ts:473](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L473)*
+*Defined in [utils/types.ts:473](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L473)*
 
 ###  alias
 
 • **alias**: *string* = "X"
 
-*Defined in [utils/types.ts:475](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L475)*
+*Defined in [utils/types.ts:475](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L475)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "4ktRjsAKxgMr2aEzv9SWmrU7Xk5FniHUrVCX4P1TZSfTLZWFM"
 
-*Defined in [utils/types.ts:474](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L474)*
+*Defined in [utils/types.ts:474](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L474)*
 
 ###  vm
 
 • **vm**: *string* = "avm"
 
-*Defined in [utils/types.ts:476](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L476)*
+*Defined in [utils/types.ts:476](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L476)*
 
 ___
 
@@ -85,25 +85,25 @@ ___
 
 ### ▪ **n2_contracts**: *object*
 
-*Defined in [utils/types.ts:485](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L485)*
+*Defined in [utils/types.ts:485](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L485)*
 
 ###  alias
 
 • **alias**: *string* = "C"
 
-*Defined in [utils/types.ts:487](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L487)*
+*Defined in [utils/types.ts:487](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L487)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "2mUYSXfLrDtigwbzj1LxKVsHwELghc5sisoXrzJwLqAAQHF4i"
 
-*Defined in [utils/types.ts:486](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L486)*
+*Defined in [utils/types.ts:486](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L486)*
 
 ###  vm
 
 • **vm**: *string* = "contracts"
 
-*Defined in [utils/types.ts:488](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L488)*
+*Defined in [utils/types.ts:488](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L488)*
 
 ___
 
@@ -111,25 +111,25 @@ ___
 
 ### ▪ **n2_platform**: *object*
 
-*Defined in [utils/types.ts:479](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L479)*
+*Defined in [utils/types.ts:479](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L479)*
 
 ###  alias
 
 • **alias**: *string* = "P"
 
-*Defined in [utils/types.ts:481](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L481)*
+*Defined in [utils/types.ts:481](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L481)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "11111111111111111111111111111111LpoYY"
 
-*Defined in [utils/types.ts:480](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L480)*
+*Defined in [utils/types.ts:480](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L480)*
 
 ###  vm
 
 • **vm**: *string* = "platform"
 
-*Defined in [utils/types.ts:482](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L482)*
+*Defined in [utils/types.ts:482](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L482)*
 
 ___
 
@@ -137,25 +137,25 @@ ___
 
 ### ▪ **n3_avm**: *object*
 
-*Defined in [utils/types.ts:491](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L491)*
+*Defined in [utils/types.ts:491](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L491)*
 
 ###  alias
 
 • **alias**: *string* = "X"
 
-*Defined in [utils/types.ts:493](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L493)*
+*Defined in [utils/types.ts:493](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L493)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "rrEWX7gc7D9mwcdrdBxBTdqh1a7WDVsMuadhTZgyXfFcRz45L"
 
-*Defined in [utils/types.ts:492](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L492)*
+*Defined in [utils/types.ts:492](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L492)*
 
 ###  vm
 
 • **vm**: *string* = "avm"
 
-*Defined in [utils/types.ts:494](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L494)*
+*Defined in [utils/types.ts:494](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L494)*
 
 ___
 
@@ -163,25 +163,25 @@ ___
 
 ### ▪ **n3_contracts**: *object*
 
-*Defined in [utils/types.ts:503](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L503)*
+*Defined in [utils/types.ts:503](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L503)*
 
 ###  alias
 
 • **alias**: *string* = "C"
 
-*Defined in [utils/types.ts:505](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L505)*
+*Defined in [utils/types.ts:505](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L505)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "zJytnh96Pc8rM337bBrtMvJDbEdDNjcXG3WkTNCiLp18ergm9"
 
-*Defined in [utils/types.ts:504](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L504)*
+*Defined in [utils/types.ts:504](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L504)*
 
 ###  vm
 
 • **vm**: *string* = "contracts"
 
-*Defined in [utils/types.ts:506](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L506)*
+*Defined in [utils/types.ts:506](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L506)*
 
 ___
 
@@ -189,22 +189,22 @@ ___
 
 ### ▪ **n3_platform**: *object*
 
-*Defined in [utils/types.ts:497](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L497)*
+*Defined in [utils/types.ts:497](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L497)*
 
 ###  alias
 
 • **alias**: *string* = "P"
 
-*Defined in [utils/types.ts:499](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L499)*
+*Defined in [utils/types.ts:499](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L499)*
 
 ###  blockchainID
 
 • **blockchainID**: *string* = "11111111111111111111111111111111LpoYY"
 
-*Defined in [utils/types.ts:498](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L498)*
+*Defined in [utils/types.ts:498](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L498)*
 
 ###  vm
 
 • **vm**: *string* = "platform"
 
-*Defined in [utils/types.ts:500](https://github.com/ava-labs/slopes/blob/65cee65/src/utils/types.ts#L500)*
+*Defined in [utils/types.ts:500](https://github.com/ava-labs/slopes/blob/ba50532/src/utils/types.ts#L500)*


### PR DESCRIPTION
Add optional denomination parameter to Slopes `createFixedCapAsset` and `createVariableCapAsset`.